### PR TITLE
galician translation by Carlos Vieito and Alexandre Espinosa

### DIFF
--- a/src/locale/locales/gl/messages.po
+++ b/src/locale/locales/gl/messages.po
@@ -1,25 +1,25 @@
 msgid ""
 msgstr ""
-"POT-Creation-Date: 2024-11-11 18:05-0800\n"
+"POT-Creation-Date: 2024-11-15 01:56+0530\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: @lingui/cli\n"
 "Language: gl\n"
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: \n"
-"Last-Translator: xurxogp\n"
-"Language-Team: xurxogp\n"
+"PO-Revision-Date: 2024-11-22 23:26+0100\n"
+"Last-Translator: alexandregz\n"
+"Language-Team: alexandregz\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: PO File Editor https://pofile.net/free-po-editor\n"
 
 #: src/screens/Messages/components/ChatListItem.tsx:130
 msgid "(contains embedded content)"
-msgstr "(contén contido incrustado)"
+msgstr "(contén contido embedido)"
 
 #: src/view/com/modals/VerifyEmail.tsx:150
 msgid "(no email)"
-msgstr "(sen correo)"
+msgstr "(sen correo electrónico)"
 
 #: src/view/com/notifications/FeedItem.tsx:232
 #: src/view/com/notifications/FeedItem.tsx:327
@@ -34,21 +34,21 @@ msgstr "{0, plural, one {# día} other {# días}}"
 msgid "{0, plural, one {# hour} other {# hours}}"
 msgstr "{0, plural, one {# hora} other {# horas}}"
 
-#: src/components/moderation/LabelsOnMe.tsx:55
-#~ msgid "{0, plural, one {# label has been placed on this account} other {# labels has been placed on this account}}"
-#~ msgstr ""
-
 #: src/components/moderation/LabelsOnMe.tsx:54
-msgid "{0, plural, one {# label has been placed on this account} other {# labels have been placed on this account}}"
-msgstr "{0, plural, one {se ha colocado # etiqueta en esta cuenta} other {se han colocado # etiquetas en esta cuenta}}"
-
-#: src/components/moderation/LabelsOnMe.tsx:61
-#~ msgid "{0, plural, one {# label has been placed on this content} other {# labels has been placed on this content}}"
-#~ msgstr ""
+msgid ""
+"{0, plural, one {# label has been placed on this account} other {# labels "
+"have been placed on this account}}"
+msgstr ""
+"{0, plural, one {colocouse # etiqueta nesta conta} other {colocáronse # "
+"etiquetas nesta conta}}"
 
 #: src/components/moderation/LabelsOnMe.tsx:60
-msgid "{0, plural, one {# label has been placed on this content} other {# labels have been placed on this content}}"
-msgstr "{0, plural, one {# label has been placed on this content} other {# labels have been placed on this content}}"
+msgid ""
+"{0, plural, one {# label has been placed on this content} other {# labels "
+"have been placed on this content}}"
+msgstr ""
+"{0, plural, one {colocouse # etiqueta neste contido} other {colocáronse # "
+"etiquetas neste contido}}"
 
 #: src/lib/hooks/useTimeAgo.ts:136
 msgid "{0, plural, one {# minute} other {# minutes}}"
@@ -60,38 +60,34 @@ msgstr "{0, plural, one {# mes} other {# meses}}"
 
 #: src/view/com/util/post-ctrls/RepostButton.tsx:73
 msgid "{0, plural, one {# repost} other {# reposts}}"
-msgstr "{0, plural, one {# repost} other {# reposts}}"
+msgstr "{0, plural, one {# rechío} other {# rechíos}}"
 
 #: src/lib/hooks/useTimeAgo.ts:126
 msgid "{0, plural, one {# second} other {# seconds}}"
 msgstr "{0, plural, one {# segundo} other {# segundos}}"
 
-#: src/components/KnownFollowers.tsx:179
-#~ msgid "{0, plural, one {and # other} other {and # others}}"
-#~ msgstr ""
-
 #: src/components/ProfileHoverCard/index.web.tsx:398
 #: src/screens/Profile/Header/Metrics.tsx:23
 msgid "{0, plural, one {follower} other {followers}}"
-msgstr "{0, plural, one {follower} other {followers}}"
+msgstr "{0, plural, one {seguidor} other {seguidores}}"
 
 #: src/components/ProfileHoverCard/index.web.tsx:402
 #: src/screens/Profile/Header/Metrics.tsx:27
 msgid "{0, plural, one {following} other {following}}"
-msgstr "{0, plural, one {following} other {following}}"
+msgstr "{0, plural, one {seguindo} other {seguindo}}"
 
 #: src/view/com/util/post-ctrls/PostCtrls.tsx:300
 msgid "{0, plural, one {Like (# like)} other {Like (# likes)}}"
-msgstr "{0, plural, one {Gústame (# gústame)} other {Gústame (# gústame)}}"
+msgstr "{0, plural, one {Préstame (# préstame)} other {Préstanme (# préstanme)}}"
 
 #: src/view/com/post-thread/PostThreadItem.tsx:434
 msgid "{0, plural, one {like} other {likes}}"
-msgstr "{0, plural, one {like} other {likes}}"
+msgstr "{0, plural, one {préstame} other {préstanme}}"
 
 #: src/components/FeedCard.tsx:213
 #: src/view/com/feeds/FeedSourceCard.tsx:300
 msgid "{0, plural, one {Liked by # user} other {Liked by # users}}"
-msgstr "{0, plural, one {Gustoulle # user} other {Gustoulle # users}}"
+msgstr "{0, plural, one {Gustoulle a # user} other {Gustoulle a # users}}"
 
 #: src/screens/Profile/Header/Metrics.tsx:59
 msgid "{0, plural, one {post} other {posts}}"
@@ -99,11 +95,11 @@ msgstr "{0, plural, one {post} other {posts}}"
 
 #: src/view/com/post-thread/PostThreadItem.tsx:418
 msgid "{0, plural, one {quote} other {quotes}}"
-msgstr "{0, plural, one {quote} other {quotes}}"
+msgstr "{0, plural, one {cita} other {citas}}"
 
 #: src/view/com/util/post-ctrls/PostCtrls.tsx:257
 msgid "{0, plural, one {Reply (# reply)} other {Reply (# replies)}}"
-msgstr "{0, plural, one {Responder (# resposta)} other {Responder (# respostas)}}"
+msgstr "{0, plural, one {Respostar (# resposta)} other {Respostar (# respostas)}}"
 
 #: src/view/com/post-thread/PostThreadItem.tsx:400
 msgid "{0, plural, one {repost} other {reposts}}"
@@ -111,21 +107,23 @@ msgstr "{0, plural, one {repost} other {reposts}}"
 
 #: src/view/com/util/post-ctrls/PostCtrls.tsx:296
 msgid "{0, plural, one {Unlike (# like)} other {Unlike (# likes)}}"
-msgstr "{0, plural, one {Non me gusta (# gústame)} other {Non me gusta (# gústame)}}"
+msgstr ""
+"{0, plural, one {Non me presta (# gústame)} other {Non me presta (# "
+"gústame)}}"
 
-#. Pattern: {wordValue} in tags
 #: src/components/dialogs/MutedWords.tsx:475
+#. Pattern: {wordValue} in tags
 msgid "{0} <0>in <1>tags</1></0>"
-msgstr "{0} <0>nas <1>etiquetas</1></0>"
+msgstr "{0} <0>en <1>tags</1></0>"
 
-#. Pattern: {wordValue} in text, tags
 #: src/components/dialogs/MutedWords.tsx:465
+#. Pattern: {wordValue} in text, tags
 msgid "{0} <0>in <1>text & tags</1></0>"
-msgstr "{0} <0>no <1>texto e etiquetas</1></0>"
+msgstr "{0} <0>en <1>texto e etiquetas</1></0>"
 
 #: src/screens/StarterPack/StarterPackLandingScreen.tsx:219
 msgid "{0} joined this week"
-msgstr "{0} uniuse esta semana"
+msgstr "{0} uníronse esta semana"
 
 #: src/view/com/util/post-embeds/VideoEmbedInner/web-controls/Scrubber.tsx:195
 msgid "{0} of {1}"
@@ -133,85 +131,61 @@ msgstr "{0} de {1}"
 
 #: src/screens/StarterPack/StarterPackScreen.tsx:478
 msgid "{0} people have used this starter pack!"
-msgstr "{0} persoas empregaron este paquete de inicio!"
-
-#: src/view/screens/ProfileList.tsx:286
-#~ msgid "{0} your feeds"
-#~ msgstr "{0} das túas fontes"
+msgstr "{0} persoas empregaron este paquete de comezo!"
 
 #: src/view/com/util/UserAvatar.tsx:435
 msgid "{0}'s avatar"
-msgstr "Avatar de {0}"
+msgstr "avatar de {0}"
 
 #: src/screens/StarterPack/Wizard/StepDetails.tsx:68
 msgid "{0}'s favorite feeds and people - join me!"
-msgstr "As fontes e persoas favoritas de {0} - únete a min!"
+msgstr "As canles e persoas favoritas de {0}, únete a min!"
 
 #: src/screens/StarterPack/Wizard/StepDetails.tsx:47
 msgid "{0}'s starter pack"
-msgstr "Paquete de inicio de {0}"
+msgstr "paquete de comezo de {0}"
 
-#. How many days have passed, displayed in a narrow form
 #: src/lib/hooks/useTimeAgo.ts:158
+#. How many days have passed, displayed in a narrow form
 msgid "{0}d"
 msgstr "{0}d"
 
-#. How many hours have passed, displayed in a narrow form
 #: src/lib/hooks/useTimeAgo.ts:148
+#. How many hours have passed, displayed in a narrow form
 msgid "{0}h"
 msgstr "{0}h"
 
-#. How many minutes have passed, displayed in a narrow form
 #: src/lib/hooks/useTimeAgo.ts:138
+#. How many minutes have passed, displayed in a narrow form
 msgid "{0}m"
 msgstr "{0}m"
 
-#. How many months have passed, displayed in a narrow form
 #: src/lib/hooks/useTimeAgo.ts:169
+#. How many months have passed, displayed in a narrow form
 msgid "{0}mo"
-msgstr "{0}mes/es"
+msgstr "{0}mes"
 
-#. How many seconds have passed, displayed in a narrow form
 #: src/lib/hooks/useTimeAgo.ts:128
+#. How many seconds have passed, displayed in a narrow form
 msgid "{0}s"
 msgstr "{0}s"
 
 #: src/components/LabelingServiceCard/index.tsx:96
 msgid "{count, plural, one {Liked by # user} other {Liked by # users}}"
-msgstr "{count, plural, one {Gustoulle a # usuario} other {Gustoulle a # usuarios}}"
-
-#: src/lib/hooks/useTimeAgo.ts:69
-#~ msgid "{diff, plural, one {day} other {days}}"
-#~ msgstr ""
-
-#: src/lib/hooks/useTimeAgo.ts:64
-#~ msgid "{diff, plural, one {hour} other {hours}}"
-#~ msgstr ""
-
-#: src/lib/hooks/useTimeAgo.ts:59
-#~ msgid "{diff, plural, one {minute} other {minutes}}"
-#~ msgstr ""
-
-#: src/lib/hooks/useTimeAgo.ts:75
-#~ msgid "{diff, plural, one {month} other {months}}"
-#~ msgstr ""
-
-#: src/lib/hooks/useTimeAgo.ts:54
-#~ msgid "{diffSeconds, plural, one {second} other {seconds}}"
-#~ msgstr ""
+msgstr "{count, plural, one {Liked by # user} outro {Liked by # users}}"
 
 #: src/lib/generate-starterpack.ts:108
 #: src/screens/StarterPack/Wizard/index.tsx:183
 msgid "{displayName}'s Starter Pack"
-msgstr "Paquete de inicio de {displayName}"
+msgstr "Paquete de comezo de {displayName}"
 
 #: src/screens/SignupQueued.tsx:207
 msgid "{estimatedTimeHrs, plural, one {hour} other {hours}}"
-msgstr ""
+msgstr "{estimatedTimeHrs, plural, one {hour} other {hours}}"
 
 #: src/screens/SignupQueued.tsx:213
 msgid "{estimatedTimeMins, plural, one {minute} other {minutes}}"
-msgstr ""
+msgstr "{estimatedTimeMins, plural, one {minute} other {minutes}}\n"
 
 #: src/components/ProfileHoverCard/index.web.tsx:508
 #: src/screens/Profile/Header/Metrics.tsx:50
@@ -220,13 +194,13 @@ msgstr "{following} seguindo"
 
 #: src/components/dms/dialogs/SearchablePeopleList.tsx:384
 msgid "{handle} can't be messaged"
-msgstr "Non se pode enviar mensaxes a {handle}"
+msgstr "Non se pode enviar unha mensaxe a {handle}"
 
 #: src/screens/Profile/Header/ProfileHeaderLabeler.tsx:284
 #: src/screens/Profile/Header/ProfileHeaderLabeler.tsx:297
 #: src/view/screens/ProfileFeed.tsx:591
 msgid "{likeCount, plural, one {Liked by # user} other {Liked by # users}}"
-msgstr ""
+msgstr "{likeCount, plural, one {Liked by # user} other {Liked by # users}}"
 
 #: src/view/shell/Drawer.tsx:477
 msgid "{numUnreadNotifications} unread"
@@ -234,57 +208,27 @@ msgstr "{numUnreadNotifications} sen ler"
 
 #: src/components/NewskieDialog.tsx:116
 msgid "{profileName} joined Bluesky {0} ago"
-msgstr "{profileName} uniuse a Bluesky hai {0}"
+msgstr "{profileName} uniuse a Bluesky fai {0}"
 
 #: src/components/NewskieDialog.tsx:111
 msgid "{profileName} joined Bluesky using a starter pack {0} ago"
-msgstr "{profileName} uniuse a Bluesky empregando un paquete de inicio hai {0}"
-
-#: src/view/screens/PreferencesFollowingFeed.tsx:67
-#~ msgid "{value, plural, =0 {Show all replies} one {Show replies with at least # like} other {Show replies with at least # likes}}"
-#~ msgstr ""
-
-#: src/components/WhoCanReply.tsx:296
-#~ msgid "<0/> members"
-#~ msgstr "<0/> membros"
-
-#: src/screens/StarterPack/Wizard/index.tsx:485
-#~ msgid "<0>{0} </0>and<1> </1><2>{1} </2>are included in your starter pack"
-#~ msgstr "<0>{0} </0>e<1> </1><2>{1} </2>están incluídos no teu paquete de inicio"
-
-#: src/screens/StarterPack/Wizard/index.tsx:475
-msgctxt "profiles"
-msgid "<0>{0}, </0><1>{1}, </1>and {2, plural, one {# other} other {# others}} are included in your starter pack"
-msgstr "<0>{0}, </0><1>{1}, </1>e {2, plural, one {# outro} other {# outros}} están incluídos no teu paquete de inicio"
-
-#: src/screens/StarterPack/Wizard/index.tsx:528
-msgctxt "feeds"
-msgid "<0>{0}, </0><1>{1}, </1>and {2, plural, one {# other} other {# others}} are included in your starter pack"
-msgstr "<0>{0}, </0><1>{1}, </1>and {2, plural, one {# other} other {# others}} están incluídos no teu paquete de inicio"
-
-#: src/screens/StarterPack/Wizard/index.tsx:497
-#~ msgid "<0>{0}, </0><1>{1}, </1>and {2} {3, plural, one {other} other {others}} are included in your starter pack"
-#~ msgstr "<0>{0}, </0><1>{1}, </1>and {2} {3, plural, one {other} other {others}} están incluídos no teu paquete de inicio"
+msgstr "{profileName} uniuse a Bluesky empregando un paquete de comezo fai {0}"
 
 #: src/view/shell/Drawer.tsx:97
 msgid "<0>{0}</0> {1, plural, one {follower} other {followers}}"
-msgstr "<0>{0}</0> {1, plural, one {follower} other {followers}}"
+msgstr "<0>{0}</0> {1, plural, one {follower} outros {followers}}\n"
 
 #: src/view/shell/Drawer.tsx:108
 msgid "<0>{0}</0> {1, plural, one {following} other {following}}"
-msgstr "<0>{0}</0> {1, plural, one {following} other {following}}"
+msgstr "<0>{0}</0> {1, plural, one {following} outro {following}}\n"
 
 #: src/screens/StarterPack/Wizard/index.tsx:516
 msgid "<0>{0}</0> and<1> </1><2>{1} </2>are included in your starter pack"
-msgstr "<0>{0}</0> e<1> </1><2>{1} </2>están incluídos no teu paquete de inicio"
-
-#: src/view/shell/Drawer.tsx:96
-#~ msgid "<0>{0}</0> following"
-#~ msgstr "<0>{0}</0> seguindo"
+msgstr "<0>{0}</0> and<1> </1><2>{1} </2>están incluídos no paquete de inicio"
 
 #: src/screens/StarterPack/Wizard/index.tsx:509
 msgid "<0>{0}</0> is included in your starter pack"
-msgstr "<0>{0}</0> está incluído no teu paquete de inicio"
+msgstr "<0>{0}</0> está incluído no paquete de inicio"
 
 #: src/components/WhoCanReply.tsx:274
 msgid "<0>{0}</0> members"
@@ -292,28 +236,15 @@ msgstr "<0>{0}</0> membros"
 
 #: src/components/dms/DateDivider.tsx:69
 msgid "<0>{date}</0> at {time}"
-msgstr "<0>{date}</0> ás {time}"
-
-#: src/components/ProfileHoverCard/index.web.tsx:437
-#~ msgid "<0>{followers} </0><1>{pluralizedFollowers}</1>"
-#~ msgstr ""
-
-#: src/components/ProfileHoverCard/index.web.tsx:449
-#: src/screens/Profile/Header/Metrics.tsx:45
-#~ msgid "<0>{following} </0><1>following</1>"
-#~ msgstr "<0>{following} </0><1>seguindo</1>"
-
-#: src/view/com/modals/SelfLabel.tsx:135
-#~ msgid "<0>Not Applicable.</0> This warning is only available for posts with media attached."
-#~ msgstr "<0>Non aplicabél.</0> Este aviso é só para as publicacións con medios anexados."
+msgstr "<0>{date}</0> en {time}"
 
 #: src/screens/StarterPack/Wizard/index.tsx:466
 msgid "<0>You</0> and<1> </1><2>{0} </2>are included in your starter pack"
-msgstr "<0>Ti</0> e<1> </1><2>{0} </2>estades incluídos no teu paquete de inicio"
+msgstr "<0>You</0> and<1> </1><2>{0} </2>están incluídos no paquete de inicio"
 
 #: src/screens/Profile/Header/Handle.tsx:53
 msgid "⚠Invalid Handle"
-msgstr "⚠Nome de usuario non válido"
+msgstr "⚠Alcume inválido"
 
 #: src/components/dialogs/MutedWords.tsx:193
 msgid "24 hours"
@@ -331,18 +262,14 @@ msgstr "30 días"
 msgid "7 days"
 msgstr "7 días"
 
-#: src/tours/Tooltip.tsx:70
-#~ msgid "A help tooltip"
-#~ msgstr "Unha indicación de axuda"
-
 #: src/view/com/util/ViewHeader.tsx:89
 #: src/view/screens/Search/Search.tsx:882
 msgid "Access navigation links and settings"
-msgstr "Acceder a ligazóns de navegación e axustes"
+msgstr "Acceder a ligazóns e configuracións de navegación"
 
 #: src/view/com/home/HomeHeaderLayoutMobile.tsx:56
 msgid "Access profile and other navigation links"
-msgstr "Acceder ao perfil e a outras ligazóns de navegación"
+msgstr "Acceder ao perfil e outras ligazóns de navegación"
 
 #: src/view/screens/Settings/index.tsx:464
 msgid "Accessibility"
@@ -355,11 +282,7 @@ msgstr "Axustes de accesibilidade"
 #: src/Navigation.tsx:317
 #: src/view/screens/AccessibilitySettings.tsx:71
 msgid "Accessibility Settings"
-msgstr "Axustes de Accesibilidade"
-
-#: src/components/moderation/LabelsOnMe.tsx:42
-#~ msgid "account"
-#~ msgstr "conta"
+msgstr "Axustes de accesibilidade"
 
 #: src/screens/Login/LoginForm.tsx:176
 #: src/view/screens/Settings/index.tsx:316
@@ -382,19 +305,19 @@ msgstr "Conta silenciada"
 #: src/components/moderation/ModerationDetailsDialog.tsx:102
 #: src/lib/moderation/useModerationCauseDescription.ts:96
 msgid "Account Muted"
-msgstr "Conta Silenciada"
+msgstr "Conta silenciada"
 
 #: src/components/moderation/ModerationDetailsDialog.tsx:88
 msgid "Account Muted by List"
-msgstr "Conta silenciada por unha lista"
+msgstr "Conta silenciada por listaxe"
 
 #: src/view/com/util/AccountDropdownBtn.tsx:43
 msgid "Account options"
-msgstr "Opcións da conta"
+msgstr "Opcións de conta"
 
 #: src/view/com/util/AccountDropdownBtn.tsx:59
 msgid "Account removed from quick access"
-msgstr "Conta eliminada do acceso rápido"
+msgstr "Conta elimada de acceso rápido"
 
 #: src/screens/Profile/Header/ProfileHeaderStandard.tsx:127
 #: src/view/com/profile/ProfileMenu.tsx:122
@@ -403,7 +326,7 @@ msgstr "Conta desbloqueada"
 
 #: src/view/com/profile/ProfileMenu.tsx:157
 msgid "Account unfollowed"
-msgstr "Conta non seguida"
+msgstr "Deixaches de seguir a esta conta"
 
 #: src/view/com/profile/ProfileMenu.tsx:98
 msgid "Account unmuted"
@@ -418,20 +341,20 @@ msgstr "Engadir"
 
 #: src/screens/StarterPack/Wizard/index.tsx:577
 msgid "Add {0} more to continue"
-msgstr "Engadir {0} máis para continuar"
+msgstr "Agregar {0} máis para continuar"
 
 #: src/components/StarterPack/Wizard/WizardListCard.tsx:59
 msgid "Add {displayName} to starter pack"
-msgstr "Engadir {displayName} ao paquete de inicio"
+msgstr "Agregar {displayName} ao paquete de inicio"
 
 #: src/view/com/composer/labels/LabelsBtn.tsx:108
 #: src/view/com/composer/labels/LabelsBtn.tsx:113
 msgid "Add a content warning"
-msgstr "Engadir un aviso de contido"
+msgstr "Engadir advertencia de contido"
 
 #: src/view/screens/ProfileList.tsx:930
 msgid "Add a user to this list"
-msgstr "Engadir un usuario a esta lista"
+msgstr "Engadir conta a esta lista"
 
 #: src/components/dialogs/SwitchAccount.tsx:55
 #: src/screens/Deactivated.tsx:199
@@ -450,10 +373,6 @@ msgstr "Engadir conta"
 msgid "Add alt text"
 msgstr "Engadir texto alternativo"
 
-#: src/view/com/composer/GifAltText.tsx:175
-#~ msgid "Add ALT text"
-#~ msgstr "Engadir texto alternativo"
-
 #: src/view/com/composer/videos/SubtitleDialog.tsx:107
 msgid "Add alt text (optional)"
 msgstr "Engadir texto alternativo (opcional)"
@@ -462,7 +381,7 @@ msgstr "Engadir texto alternativo (opcional)"
 #: src/view/screens/AppPasswords.tsx:153
 #: src/view/screens/AppPasswords.tsx:166
 msgid "Add App Password"
-msgstr "Engadir un contrasinal de aplicación"
+msgstr "Engadir contrasinal de app"
 
 #: src/components/dialogs/MutedWords.tsx:321
 msgid "Add mute word for configured settings"
@@ -470,73 +389,67 @@ msgstr "Engadir palabra silenciada nos axustes"
 
 #: src/components/dialogs/MutedWords.tsx:112
 msgid "Add muted words and tags"
-msgstr "Engadir palabras e etiquetas silenciadas"
-
-#: src/screens/StarterPack/Wizard/index.tsx:197
-#~ msgid "Add people to your starter pack that you think others will enjoy following"
-#~ msgstr "Engadir xente ao teu paquete de inicio coa que cres que outros gozarán seguindoas"
+msgstr "Engadir palabras silenciadas e etiquetas"
 
 #: src/screens/Home/NoFeedsPinned.tsx:99
 msgid "Add recommended feeds"
-msgstr "Engadir fontes recomendadas"
+msgstr "Engadir canles recomendadas"
 
 #: src/screens/StarterPack/Wizard/index.tsx:497
 msgid "Add some feeds to your starter pack!"
-msgstr "Engadir algunhas fontes ao teu paquete de inicio!"
+msgstr "Engadir algunhas canles ao teu pack de comezo!"
 
 #: src/screens/Feeds/NoFollowingFeed.tsx:41
 msgid "Add the default feed of only people you follow"
-msgstr "Engadir a fonte predefinida só da xente que sigues"
+msgstr "Engade a canle predeterminada só das persoas que segues"
 
 #: src/view/com/modals/ChangeHandle.tsx:403
 msgid "Add the following DNS record to your domain:"
-msgstr "Engadir o seguinte rexistro DNS ao teu dominio:"
+msgstr "Engade o seguinte rexistro DNS ao teu dominio:"
 
 #: src/components/FeedCard.tsx:296
 msgid "Add this feed to your feeds"
-msgstr "Engadir esta fonte ás túas fontes"
+msgstr "Engade esta canle ás súas novas"
 
 #: src/view/com/profile/ProfileMenu.tsx:243
 #: src/view/com/profile/ProfileMenu.tsx:246
 msgid "Add to Lists"
-msgstr "Engadir ás listas"
+msgstr "Engadir a listaxes"
 
 #: src/view/com/feeds/FeedSourceCard.tsx:266
 msgid "Add to my feeds"
-msgstr "Engadir ás miñas fontes"
+msgstr "Engadir ás miñas canles"
 
 #: src/view/com/modals/ListAddRemoveUsers.tsx:192
 #: src/view/com/modals/UserAddRemoveLists.tsx:162
 msgid "Added to list"
-msgstr "Engadido á lista"
+msgstr "Engadido á listaxe"
 
 #: src/view/com/feeds/FeedSourceCard.tsx:125
 msgid "Added to my feeds"
-msgstr "Engadido ás miñas fontes"
-
-#: src/view/screens/PreferencesFollowingFeed.tsx:171
-#~ msgid "Adjust the number of likes a reply must have to be shown in your feed."
-#~ msgstr ""
+msgstr "Engadida ás miñas canles"
 
 #: src/components/moderation/ContentHider.tsx:83
 #: src/lib/moderation/useGlobalLabelStrings.ts:34
 #: src/lib/moderation/useModerationCauseDescription.ts:144
 #: src/view/com/composer/labels/LabelsBtn.tsx:129
 msgid "Adult Content"
-msgstr "Contido para adultos"
+msgstr "Contido para persoas adultas"
 
 #: src/screens/Moderation/index.tsx:366
 msgid "Adult content can only be enabled via the Web at <0>bsky.app</0>."
-msgstr "O contido para adultos só pode ser habilitado a través da web en <0>bsky.app</0>."
+msgstr ""
+"O contido para persoas adultas só se pode habilitar a través da web en "
+"<0>bsky.app</0>."
 
 #: src/components/moderation/LabelPreference.tsx:241
 msgid "Adult content is disabled."
-msgstr "Contido para adultos deshabilitado."
+msgstr "O contido para persoas adultas está desactivado."
 
 #: src/view/com/composer/labels/LabelsBtn.tsx:140
 #: src/view/com/composer/labels/LabelsBtn.tsx:194
 msgid "Adult Content labels"
-msgstr "Etiquetas de contido para adultos"
+msgstr "Etiquetas de contido para persoas adultas"
 
 #: src/screens/Moderation/index.tsx:410
 #: src/view/screens/Settings/index.tsx:653
@@ -545,25 +458,20 @@ msgstr "Avanzado"
 
 #: src/state/shell/progress-guide.tsx:171
 msgid "Algorithm training complete!"
-msgstr "Adestramento do algoritmo concluído!"
+msgstr "Adestramento de algoritmo completo!"
 
 #: src/screens/StarterPack/StarterPackScreen.tsx:381
 msgid "All accounts have been followed!"
-msgstr "Todas as contas foron seguidas!"
+msgstr "Seguíronse todas as contas!"
 
 #: src/view/screens/Feeds.tsx:735
 msgid "All the feeds you've saved, right in one place."
-msgstr "Todas as fontes que gardaches, nun único lugar."
+msgstr "Todas as túas canles gardadas, nun só lugar."
 
 #: src/view/com/modals/AddAppPasswords.tsx:188
 #: src/view/com/modals/AddAppPasswords.tsx:195
 msgid "Allow access to your direct messages"
 msgstr "Permitir o acceso ás túas mensaxes directas"
-
-#: src/screens/Messages/Settings.tsx:61
-#: src/screens/Messages/Settings.tsx:64
-#~ msgid "Allow messages from"
-#~ msgstr "Permitir mensaxes de"
 
 #: src/screens/Messages/Settings.tsx:64
 #: src/screens/Messages/Settings.tsx:67
@@ -576,7 +484,7 @@ msgstr "Permitir respostas de:"
 
 #: src/view/screens/AppPasswords.tsx:272
 msgid "Allows access to direct messages"
-msgstr "Permite o acceso ás mensaxes directas"
+msgstr "Permitir acceso a mensaxes directas"
 
 #: src/screens/Login/ForgotPasswordForm.tsx:171
 #: src/view/com/modals/ChangePassword.tsx:171
@@ -585,7 +493,7 @@ msgstr "Xa tes un código?"
 
 #: src/screens/Login/ChooseAccountForm.tsx:43
 msgid "Already signed in as @{0}"
-msgstr "Xa iniciaches sesión como @{0}"
+msgstr "Sesión xa comezada como @{0}"
 
 #: src/view/com/composer/GifAltText.tsx:100
 #: src/view/com/composer/photos/Gallery.tsx:184
@@ -604,99 +512,99 @@ msgstr "Texto alternativo"
 
 #: src/view/com/util/post-embeds/GifEmbed.tsx:191
 msgid "Alt Text"
-msgstr "Texto Alternativo"
+msgstr "Texto alternativo"
 
 #: src/view/com/composer/photos/Gallery.tsx:252
-msgid "Alt text describes images for blind and low-vision users, and helps give context to everyone."
-msgstr "O texto alternativo describe imaxes aos usuarios invidentes ou con pouca visión, alén de dar máis información do contexto."
+msgid ""
+"Alt text describes images for blind and low-vision users, and helps give "
+"context to everyone."
+msgstr ""
+"O texto alternativo describe imaxes a persoas cegas ou con baixa visión e "
+"axuda a dar máis contexto."
 
 #: src/view/com/composer/GifAltText.tsx:179
 #: src/view/com/composer/photos/ImageAltTextDialog.tsx:139
 msgid "Alt text will be truncated. Limit: {0} characters."
-msgstr "O texto alternativo ficará truncado. Limite: {0} caracteres."
+msgstr "O texto alternativo será truncado. Límite: {0} caracteres."
 
 #: src/view/com/modals/VerifyEmail.tsx:132
 #: src/view/screens/Settings/DisableEmail2FADialog.tsx:95
-msgid "An email has been sent to {0}. It includes a confirmation code which you can enter below."
-msgstr "Enviouse un correo a {0}. Este inclúe un código de confirmación que podes inserir abaixo."
+msgid ""
+"An email has been sent to {0}. It includes a confirmation code which you "
+"can enter below."
+msgstr ""
+"Un código de verificación foi enviado a {0}. Ingresa ese código a "
+"continuación."
 
 #: src/view/com/modals/ChangeEmail.tsx:114
-msgid "An email has been sent to your previous address, {0}. It includes a confirmation code which you can enter below."
-msgstr "Enviouse un correo á túa conta anterior, {0}. Este inclúe un código de confirmación que podes inserir abaixo."
+msgid ""
+"An email has been sent to your previous address, {0}. It includes a "
+"confirmation code which you can enter below."
+msgstr ""
+"Un código de verificación foi enviado o teu enderezo anterior, {0}. Ingresa "
+"ese código a continuación."
 
 #: src/components/dialogs/VerifyEmailDialog.tsx:77
-msgid "An email has been sent! Please enter the confirmation code included in the email below."
-msgstr "Enviouse un correo! Por favor, insire abaixo o código de confirmación incluído no correo."
+msgid ""
+"An email has been sent! Please enter the confirmation code included in the "
+"email below."
+msgstr ""
+"Envioiuse un correo electrónico! A continuación, ingresa o código de "
+"confirmación incluido no correo electrónico."
 
 #: src/components/dialogs/GifSelect.tsx:266
 msgid "An error has occurred"
 msgstr "Produciuse un erro"
 
-#: src/components/dialogs/GifSelect.tsx:252
-#~ msgid "An error occured"
-#~ msgstr "Produciuse un erro"
-
 #: src/view/com/util/post-embeds/VideoEmbedInner/web-controls/VideoControls.tsx:422
 msgid "An error occurred"
-msgstr "Produciuse un erro"
+msgstr "Ocurreu un erro"
 
 #: src/view/com/composer/state/video.ts:412
 msgid "An error occurred while compressing the video."
-msgstr "Produciuse un erro ao comprimir o vídeo."
+msgstr "Ocurreu un erro ao comprimir o vídeo."
 
 #: src/components/StarterPack/ProfileStarterPacks.tsx:316
 msgid "An error occurred while generating your starter pack. Want to try again?"
-msgstr "Produciuse un erro ao xerar o teu paquete de inicio. Desexas tentalo de novo?"
+msgstr "Ocurreu un error ao xerar o teu paquete de inicio. Queres probar de novo?"
 
 #: src/view/com/util/post-embeds/VideoEmbed.tsx:135
 msgid "An error occurred while loading the video. Please try again later."
-msgstr "Produciuse un erro ao cargar o vídeo. Por favor, téntao de novo máis tarde."
+msgstr "Ocurreu un erro ao cargar o vídeo. Por favor, proba de novo."
 
 #: src/view/com/util/post-embeds/VideoEmbed.web.tsx:174
 msgid "An error occurred while loading the video. Please try again."
-msgstr "Produciuse un erro ao cargar o vídeo. Por favor, téntao de novo."
-
-#: src/components/dialogs/nuxs/TenMillion/index.tsx:250
-#~ msgid "An error occurred while saving the image!"
-#~ msgstr "Produciuse un erro ao gardar a imaxe!"
-
-#: src/components/StarterPack/ShareDialog.tsx:79
-#~ msgid "An error occurred while saving the image."
-#~ msgstr "Produciuse un erro ao gardar a imaxe."
+msgstr "Ocurreu un erro mentres cargaba o vídeo. Por favor, proba de novo."
 
 #: src/components/StarterPack/QrCodeDialog.tsx:71
 #: src/components/StarterPack/ShareDialog.tsx:80
 msgid "An error occurred while saving the QR code!"
-msgstr "Produciuse un erro ao gardar o código QR!"
+msgstr "Ocurreu un erro ao gardar o código QR!"
 
 #: src/view/com/composer/videos/SelectVideoBtn.tsx:87
 msgid "An error occurred while selecting the video"
-msgstr "Produciuse un erro ao seleccionar o vídeo"
-
-#: src/components/dms/MessageMenu.tsx:134
-#~ msgid "An error occurred while trying to delete the message. Please try again."
-#~ msgstr "Produciuse un erro ao tentar eliminar a mensaxe. Por favor, téntao de novo."
+msgstr "Ocurreu un erro mentres seleccionabas o vídeo"
 
 #: src/screens/StarterPack/StarterPackScreen.tsx:347
 #: src/screens/StarterPack/StarterPackScreen.tsx:369
 msgid "An error occurred while trying to follow all"
-msgstr "Produciuse un erro ao tentar seguir todo"
+msgstr "Ocurreu un erro mentres tentabas seguir a varias persoas"
 
 #: src/view/com/composer/state/video.ts:449
 msgid "An error occurred while uploading the video."
-msgstr "Produciuse un erro ao subir o vídeo."
+msgstr "Ocurreu un erro ao cargar o vídeo."
 
 #: src/lib/moderation/useReportOptions.ts:28
 msgid "An issue not included in these options"
-msgstr "Outro problema"
+msgstr "Un problema non presente nestas opcións"
 
 #: src/components/dms/dialogs/NewChatDialog.tsx:36
 msgid "An issue occurred starting the chat"
-msgstr "Produciuse un problema ao iniciar a conversa"
+msgstr "Ocurreu un erro iniciando a conversa"
 
 #: src/components/dms/dialogs/ShareViaChatDialog.tsx:47
 msgid "An issue occurred while trying to open the chat"
-msgstr "Produciuse un problema ao tentar abrir a conversa"
+msgstr "Ocurreu un erro mentres tentabas abrir as conversas."
 
 #: src/components/hooks/useFollowMethods.ts:35
 #: src/components/hooks/useFollowMethods.ts:50
@@ -705,11 +613,11 @@ msgstr "Produciuse un problema ao tentar abrir a conversa"
 #: src/view/com/profile/FollowButton.tsx:36
 #: src/view/com/profile/FollowButton.tsx:46
 msgid "An issue occurred, please try again."
-msgstr "Produciuse un problema, por favor téntao de novo."
+msgstr "Ocurreu un erro. Proba de novo."
 
 #: src/screens/Onboarding/StepInterests/index.tsx:185
 msgid "an unknown error occurred"
-msgstr "produciuse un erro descoñecido"
+msgstr "Ocurreu un erro descoñecido"
 
 #: src/components/moderation/ModerationDetailsDialog.tsx:158
 #: src/components/moderation/ModerationDetailsDialog.tsx:154
@@ -738,7 +646,7 @@ msgstr "Comportamento antisocial"
 #: src/view/screens/Search/Search.tsx:347
 #: src/view/screens/Search/Search.tsx:348
 msgid "Any language"
-msgstr "Calquera lingua"
+msgstr "Calquera idioma"
 
 #: src/view/com/composer/threadgate/ThreadgateBtn.tsx:49
 msgid "Anybody can interact"
@@ -746,29 +654,33 @@ msgstr "Calquera pode interactuar"
 
 #: src/view/screens/LanguageSettings.tsx:94
 msgid "App Language"
-msgstr "Lingua da aplicación"
+msgstr "Idioma da interfaz"
 
 #: src/view/screens/AppPasswords.tsx:232
 msgid "App password deleted"
-msgstr "Contrasinal da aplicación eliminado"
+msgstr "Contrasinal de app eliminado"
 
 #: src/view/com/modals/AddAppPasswords.tsx:138
-msgid "App Password names can only contain letters, numbers, spaces, dashes, and underscores."
-msgstr "O contrasinal só pode conter letras, números, espazos, guións, e guións baixos."
+msgid ""
+"App Password names can only contain letters, numbers, spaces, dashes, and "
+"underscores."
+msgstr ""
+"O nome dun contrasinal de app só pode conter letras, números, espazos, "
+"guións e guións baixos."
 
 #: src/view/com/modals/AddAppPasswords.tsx:103
 msgid "App Password names must be at least 4 characters long."
-msgstr "O contrasinal debe ter 4 caracteres como mínimo."
+msgstr "O nome dun contrasinal de app debe ter polo menos 4 caracteres."
 
 #: src/view/screens/Settings/index.tsx:664
 msgid "App password settings"
-msgstr "Axustes do contrasinal da aplicación"
+msgstr "Axustes de contrasinais de app"
 
 #: src/Navigation.tsx:285
 #: src/view/screens/AppPasswords.tsx:197
 #: src/view/screens/Settings/index.tsx:673
 msgid "App Passwords"
-msgstr "Contrasinais da aplicación"
+msgstr "Contrasinais da app"
 
 #: src/components/moderation/LabelsOnMeDialog.tsx:148
 #: src/components/moderation/LabelsOnMeDialog.tsx:151
@@ -777,16 +689,12 @@ msgstr "Apelar"
 
 #: src/components/moderation/LabelsOnMeDialog.tsx:243
 msgid "Appeal \"{0}\" label"
-msgstr "Apelar a etiqueta \"{0}\""
+msgstr "Apelar a etiqueta de \"{0}\""
 
 #: src/components/moderation/LabelsOnMeDialog.tsx:233
 #: src/screens/Messages/components/ChatDisabled.tsx:91
 msgid "Appeal submitted"
 msgstr "Apelación enviada"
-
-#: src/components/moderation/LabelsOnMeDialog.tsx:193
-#~ msgid "Appeal submitted."
-#~ msgstr "Apelación enviada."
 
 #: src/screens/Messages/components/ChatDisabled.tsx:51
 #: src/screens/Messages/components/ChatDisabled.tsx:53
@@ -802,68 +710,64 @@ msgstr "Aparencia"
 
 #: src/view/screens/Settings/index.tsx:476
 msgid "Appearance settings"
-msgstr "Axustes da aparencia"
+msgstr "Configuración de aparencia"
 
 #: src/Navigation.tsx:325
 msgid "Appearance Settings"
-msgstr "Axustes da Aparencia"
+msgstr "Configuración de aparencia"
 
 #: src/screens/Feeds/NoSavedFeedsOfAnyType.tsx:47
 #: src/screens/Home/NoFeedsPinned.tsx:93
 msgid "Apply default recommended feeds"
-msgstr "Aplicar as fontes predefinidas recomendadas"
-
-#: src/screens/StarterPack/StarterPackScreen.tsx:610
-#~ msgid "Are you sure you want delete this starter pack?"
-#~ msgstr "Estás certo/a de querer eliminar este paquete de inicio?"
+msgstr "Aplicar canles recomendadas predeterminados"
 
 #: src/view/screens/AppPasswords.tsx:283
 msgid "Are you sure you want to delete the app password \"{name}\"?"
-msgstr "Estás certo/a de querer eliminar o contrasinal da aplicación \"{name}\"?"
-
-#: src/components/dms/MessageMenu.tsx:123
-#~ msgid "Are you sure you want to delete this message? The message will be deleted for you, but not for other participants."
-#~ msgstr "Estás certo/a de querer eliminar esta mensaxe? A mensaxes será eliminada para ti, mais non para os outros participantes."
+msgstr "Seguro que queres eliminar o contrasinal da app \"{name}\"?"
 
 #: src/components/dms/MessageMenu.tsx:149
-msgid "Are you sure you want to delete this message? The message will be deleted for you, but not for the other participant."
-msgstr "Estás certo/a de querer eliminar esta mensaxe? A mensaxe será eliminada para ti, mais non para o outro participante."
+msgid ""
+"Are you sure you want to delete this message? The message will be deleted "
+"for you, but not for the other participant."
+msgstr ""
+"Tes a certeza de que queres eliminar esta mensaxe? A mensaxe eliminarase "
+"para ti, mais non para a outra persoa."
 
 #: src/screens/StarterPack/StarterPackScreen.tsx:632
 msgid "Are you sure you want to delete this starter pack?"
-msgstr "Estás certo/a de querer eliminar este paquete de inicio?"
+msgstr "Tes a certeza de que queres eliminar este paquete de inicio?"
 
 #: src/screens/Profile/Header/EditProfileDialog.tsx:82
 msgid "Are you sure you want to discard your changes?"
-msgstr "Estás certo/a de querer desbotar os trocos?"
-
-#: src/components/dms/ConvoMenu.tsx:189
-#~ msgid "Are you sure you want to leave this conversation? Your messages will be deleted for you, but not for other participants."
-#~ msgstr "Estás certo/a de querer saír desta conversa? As túas mensaxes serán eliminadas, mais non para os outros participantes."
+msgstr "Tes a certeza de que queres descartar os teus cambios?"
 
 #: src/components/dms/LeaveConvoPrompt.tsx:48
-msgid "Are you sure you want to leave this conversation? Your messages will be deleted for you, but not for the other participant."
-msgstr "Estás certo/a de querer rematar esta conversa? As túas mensaxes serán eliminadas, mais non para os outros participantes."
+msgid ""
+"Are you sure you want to leave this conversation? Your messages will be "
+"deleted for you, but not for the other participant."
+msgstr ""
+"Tes a certeza de que queres eliminar esta conversa? As túas mensaxes "
+"eliminaranse para ti, mais non para a outra persoa."
 
 #: src/view/com/feeds/FeedSourceCard.tsx:313
 msgid "Are you sure you want to remove {0} from your feeds?"
-msgstr "Estás certo/a de querer eliminar {0} das túas fontes?"
+msgstr "Tes a certeza de que queres eliminar  {0} das túas canles?"
 
 #: src/components/FeedCard.tsx:313
 msgid "Are you sure you want to remove this from your feeds?"
-msgstr "Estás certo/a de querer eliminar isto das túas fontes?"
+msgstr "Tes a certeza de que desexas eliminar isto das túas canles?"
 
 #: src/view/com/composer/Composer.tsx:532
 msgid "Are you sure you'd like to discard this draft?"
-msgstr "Estás certo/a de querer desbotar este borrador?"
+msgstr "Tes a certeza de quequeres descartar este borrador?"
 
 #: src/components/dialogs/MutedWords.tsx:433
 msgid "Are you sure?"
-msgstr "Estás certo/a?"
+msgstr "Realmente é o que queres?"
 
 #: src/view/com/composer/select-language/SuggestedLanguage.tsx:60
 msgid "Are you writing in <0>{0}</0>?"
-msgstr "Estás a escribir en <0>{0}</0>?"
+msgstr "Estás escribindo en <0>{0}</0>?"
 
 #: src/screens/Onboarding/index.tsx:23
 #: src/screens/Onboarding/state.ts:82
@@ -872,11 +776,11 @@ msgstr "Arte"
 
 #: src/view/com/composer/labels/LabelsBtn.tsx:170
 msgid "Artistic or non-erotic nudity."
-msgstr "Espido artístico ou non erótico."
+msgstr "Espidos artísticos ou non eróticos."
 
 #: src/screens/Signup/StepHandle.tsx:173
 msgid "At least 3 characters"
-msgstr "Polo menos 3 caracteres"
+msgstr "Cando menos 3 caracteres"
 
 #: src/components/dms/MessagesListHeader.tsx:75
 #: src/components/moderation/LabelsOnMeDialog.tsx:290
@@ -898,13 +802,9 @@ msgstr "Polo menos 3 caracteres"
 msgid "Back"
 msgstr "Atrás"
 
-#: src/screens/Onboarding/StepSuggestedAccounts/index.tsx:144
-#~ msgid "Based on your interest in {interestsText}"
-#~ msgstr "Baseado nos teus intereses por {interestsText}"
-
 #: src/view/screens/Settings/index.tsx:442
 msgid "Basics"
-msgstr "Conceptos básicos"
+msgstr "Xeral"
 
 #: src/components/dialogs/BirthDateSettings.tsx:106
 msgid "Birthday"
@@ -927,7 +827,7 @@ msgstr "Bloquear conta"
 #: src/view/com/profile/ProfileMenu.tsx:280
 #: src/view/com/profile/ProfileMenu.tsx:287
 msgid "Block Account"
-msgstr "Bloquear Conta"
+msgstr "Bloquear conta"
 
 #: src/view/com/profile/ProfileMenu.tsx:324
 msgid "Block Account?"
@@ -939,7 +839,7 @@ msgstr "Bloquear contas"
 
 #: src/view/screens/ProfileList.tsx:747
 msgid "Block list"
-msgstr "Bloquear listas"
+msgstr "Bloquear listaxe"
 
 #: src/view/screens/ProfileList.tsx:742
 msgid "Block these accounts?"
@@ -947,7 +847,7 @@ msgstr "Bloquear estas contas?"
 
 #: src/view/com/util/post-embeds/QuoteEmbed.tsx:82
 msgid "Blocked"
-msgstr "Bloqueada"
+msgstr "Bloqueado"
 
 #: src/screens/Moderation/index.tsx:280
 msgid "Blocked accounts"
@@ -956,31 +856,53 @@ msgstr "Contas bloqueadas"
 #: src/Navigation.tsx:149
 #: src/view/screens/ModerationBlockedAccounts.tsx:108
 msgid "Blocked Accounts"
-msgstr "Contas Bloqueadas"
+msgstr "Contas bloqueadas"
 
 #: src/view/com/profile/ProfileMenu.tsx:336
-msgid "Blocked accounts cannot reply in your threads, mention you, or otherwise interact with you."
-msgstr "As contas bloqueadas non poden responder nos teus fíos, mencionarte ou interactuar contigo."
+msgid ""
+"Blocked accounts cannot reply in your threads, mention you, or otherwise "
+"interact with you."
+msgstr ""
+"Se bloqueas unha conta non poderá responder os teus fíos, mencionarte nin "
+"interactuar contigo de ningunha maneira."
 
 #: src/view/screens/ModerationBlockedAccounts.tsx:116
-msgid "Blocked accounts cannot reply in your threads, mention you, or otherwise interact with you. You will not see their content and they will be prevented from seeing yours."
-msgstr "As contas bloqueadas non poden responder nos teus fíos, mencionarte ou interactuar contigo. Non verás os seus contidos e eles non verán o teu."
+msgid ""
+"Blocked accounts cannot reply in your threads, mention you, or otherwise "
+"interact with you. You will not see their content and they will be "
+"prevented from seeing yours."
+msgstr ""
+"Se bloqueas unha conta non poderá responder os teus fíos, mencionarte nin "
+"interactuar contigo de ningunha manera. Non verás o seu contido e non "
+"poderá ver o teu."
 
 #: src/view/com/post-thread/PostThread.tsx:412
 msgid "Blocked post."
-msgstr "Publicación bloqueada."
+msgstr "Chío bloqueado."
 
 #: src/screens/Profile/Sections/Labels.tsx:173
 msgid "Blocking does not prevent this labeler from placing labels on your account."
-msgstr "Bloquear non prevén a este etiquetador etiquetar na túa conta."
+msgstr ""
+"Se bloqueas a un etiquetador aínda poderá seguir aplicando etiquetas na túa "
+"conta."
 
 #: src/view/screens/ProfileList.tsx:744
-msgid "Blocking is public. Blocked accounts cannot reply in your threads, mention you, or otherwise interact with you."
-msgstr "O bloqueo é público. As contas bloqueadas non poden responder nos teus fíos, mencionarte ou interactuar contigo."
+msgid ""
+"Blocking is public. Blocked accounts cannot reply in your threads, mention "
+"you, or otherwise interact with you."
+msgstr ""
+"O bloqueo é público. Se bloqueas unha conta non poderá responder os teus "
+"fíos, mencionarte nin interactuar contigo de ningunha maneira."
 
 #: src/view/com/profile/ProfileMenu.tsx:333
-msgid "Blocking will not prevent labels from being applied on your account, but it will stop this account from replying in your threads or interacting with you."
+msgid ""
+"Blocking will not prevent labels from being applied on your account, but it "
+"will stop this account from replying in your threads or interacting with "
+"you."
 msgstr ""
+"Se bloqueas a un etiquetador aínda poderá seguir aplicando etiquetas na túa "
+"conta, mais evitará que responda nos teus fíos, que te mencione e non "
+"poderá interactuar contigo de ningunha maneira."
 
 #: src/view/com/auth/SplashScreen.web.tsx:172
 msgid "Blog"
@@ -991,71 +913,70 @@ msgstr "Blog"
 msgid "Bluesky"
 msgstr "Bluesky"
 
-#: src/view/com/auth/server-input/index.tsx:154
-#~ msgid "Bluesky is an open network where you can choose your hosting provider. Custom hosting is now available in beta for developers."
-#~ msgstr "Bluesky é unha rede aberta onde podes escoller o teu provedor de hospedaxe. A hospedaxe personalizada xa está dispoñíbel en versión beta para desenvolvedores."
-
 #: src/view/com/auth/server-input/index.tsx:151
-msgid "Bluesky is an open network where you can choose your hosting provider. If you're a developer, you can host your own server."
-msgstr "Bluesky é unha rede aberta onde podes escoller o teu provedor de hospedaxe. Se es desenvolvedor, podes crear o teu propio servidor."
+msgid ""
+"Bluesky is an open network where you can choose your hosting provider. If "
+"you're a developer, you can host your own server."
+msgstr ""
+"Bluesky é unha rede aberta onde podes elixir o teu proveedor de aloxamento. "
+"Se es desenvolves, podes aloxar o teu propio servidor."
 
 #: src/components/ProgressGuide/List.tsx:55
 msgid "Bluesky is better with friends!"
-msgstr "Bluesky é mellor con amigos!"
-
-#: src/components/dialogs/nuxs/TenMillion/index.tsx:206
-#~ msgid "Bluesky now has over 10 million users, and I was #{0}!"
-#~ msgstr "Bluesky ten sobre 10 millóns de usuarios, e eu son o #{0}!"
+msgstr "Bluesky é mellor con amizades!"
 
 #: src/components/StarterPack/ProfileStarterPacks.tsx:283
-msgid "Bluesky will choose a set of recommended accounts from people in your network."
-msgstr "Bluesky escollerá un conxunto de contas recomendadas de xente na túa rede."
+msgid ""
+"Bluesky will choose a set of recommended accounts from people in your "
+"network."
+msgstr "Bluesky elexirá un conxunto de contas recomendadas na túa rede."
 
 #: src/screens/Moderation/index.tsx:571
-msgid "Bluesky will not show your profile and posts to logged-out users. Other apps may not honor this request. This does not make your account private."
-msgstr "Bluesky non amosará o teu perfil e publicacións ao usuarios non conectados. É posíbel que outras aplicacións non respeten esta solicitude. Isto non fai que a túa conta sexa privada."
+msgid ""
+"Bluesky will not show your profile and posts to logged-out users. Other "
+"apps may not honor this request. This does not make your account private."
+msgstr ""
+"Bluesky non amosará o teu perfil ou chíos a persoas que non iniciaran "
+"sesión. É posíbel que outras apps non respecten esta solicitude. Isto non "
+"fai que a túa conta sexa privada."
 
 #: src/lib/moderation/useLabelBehaviorDescription.ts:53
 msgid "Blur images"
-msgstr "Desenfocar imaxe"
+msgstr "Desenfocar imaxes"
 
 #: src/lib/moderation/useLabelBehaviorDescription.ts:51
 msgid "Blur images and filter from feeds"
-msgstr "Desenfocar imaxe e filtrar dende as fontes"
+msgstr "Desenfocar imaxes e filtrar desde as canles"
 
 #: src/screens/Onboarding/index.tsx:30
 #: src/screens/Onboarding/state.ts:83
 msgid "Books"
 msgstr "Libros"
 
-#: src/components/dialogs/nuxs/TenMillion/index.tsx:614
-#~ msgid "Brag a little!"
-#~ msgstr "Fachendea un pouco!"
-
 #: src/components/FeedInterstitials.tsx:350
 msgid "Browse more accounts on the Explore page"
-msgstr "Procurar máis contas na páxina Explorar"
+msgstr "Explorar máis contas"
 
 #: src/components/FeedInterstitials.tsx:483
 msgid "Browse more feeds on the Explore page"
-msgstr "Procurar máis fontes na páxina Explorar"
+msgstr "Revisar máis canles"
 
 #: src/components/FeedInterstitials.tsx:332
 #: src/components/FeedInterstitials.tsx:335
 #: src/components/FeedInterstitials.tsx:465
 #: src/components/FeedInterstitials.tsx:468
 msgid "Browse more suggestions"
-msgstr "Procurar máis suxestións"
+msgstr "Explorar máis suxerencias"
 
 #: src/components/FeedInterstitials.tsx:358
 #: src/components/FeedInterstitials.tsx:492
 msgid "Browse more suggestions on the Explore page"
-msgstr "Procurar máis suxestións na páxina Explorar"
+msgstr "Explora máis suxerencias na páxina Explorar"
 
 #: src/screens/Home/NoFeedsPinned.tsx:103
 #: src/screens/Home/NoFeedsPinned.tsx:109
 msgid "Browse other feeds"
-msgstr "Procurar outras fontes"
+msgstr "Explorar outras canles"
 
 #: src/view/com/auth/SplashScreen.web.tsx:167
 msgid "Business"
@@ -1069,29 +990,25 @@ msgstr "por —"
 msgid "By {0}"
 msgstr "Por {0}"
 
-#: src/screens/Onboarding/StepAlgoFeeds/FeedCard.tsx:112
-#~ msgid "by @{0}"
-#~ msgstr "por @{0}"
-
 #: src/view/com/profile/ProfileSubpageHeader.tsx:164
 msgid "by <0/>"
 msgstr "por <0/>"
 
-#: src/screens/Signup/StepInfo/Policies.tsx:80
-#~ msgid "By creating an account you agree to the {els}."
-#~ msgstr "Ao crear unha conta, aceptas os nosos {els}."
-
 #: src/screens/Signup/StepInfo/Policies.tsx:81
 msgid "By creating an account you agree to the <0>Privacy Policy</0>."
-msgstr "Ao crear a conta aceptas a <0>Política de Privacidade</0>."
+msgstr "Ao crear unha conta, aceptas a <0>Política de privacidade</0>."
 
 #: src/screens/Signup/StepInfo/Policies.tsx:48
-msgid "By creating an account you agree to the <0>Terms of Service</0> and <1>Privacy Policy</1>."
-msgstr "Ao crear umha conta aceptas os <0>Termos do Servizo</0> e a <1>Política de Privacidade</1>."
+msgid ""
+"By creating an account you agree to the <0>Terms of Service</0> and "
+"<1>Privacy Policy</1>."
+msgstr ""
+"Ao crear unha conta, aceptas os <0>Termos de servizo</0> e a <1>Política de "
+"privacidade</1>."
 
 #: src/screens/Signup/StepInfo/Policies.tsx:68
 msgid "By creating an account you agree to the <0>Terms of Service</0>."
-msgstr "By creating an account you agree to the <0>Terms of Service</0>."
+msgstr "Ao crear unha conta, aceptas os <0>Termos de servizo</0>."
 
 #: src/view/com/profile/ProfileSubpageHeader.tsx:162
 msgid "by you"
@@ -1102,8 +1019,12 @@ msgid "Camera"
 msgstr "Cámara"
 
 #: src/view/com/modals/AddAppPasswords.tsx:180
-msgid "Can only contain letters, numbers, spaces, dashes, and underscores. Must be at least 4 characters long, but no more than 32 characters long."
-msgstr "Só pode conter letras, números, espazos, guións e guións baixos. Debe ter como mínimo 4 caracteres e non máis de 32."
+msgid ""
+"Can only contain letters, numbers, spaces, dashes, and underscores. Must be "
+"at least 4 characters long, but no more than 32 characters long."
+msgstr ""
+"Só pode contener letras, números, espazos, guións e guións baixos. Debe ter "
+"cando menos 4 caracteres, mais non máis de 32."
 
 #: src/components/Menu/index.tsx:235
 #: src/components/Prompt.tsx:129
@@ -1131,13 +1052,6 @@ msgstr "Só pode conter letras, números, espazos, guións e guións baixos. Deb
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: src/view/com/modals/CreateOrEditList.tsx:340
-#: src/view/com/modals/DeleteAccount.tsx:174
-#: src/view/com/modals/DeleteAccount.tsx:296
-msgctxt "action"
-msgid "Cancel"
-msgstr "Cancelar"
-
 #: src/view/com/modals/DeleteAccount.tsx:170
 #: src/view/com/modals/DeleteAccount.tsx:292
 msgid "Cancel account deletion"
@@ -1145,105 +1059,92 @@ msgstr "Cancelar a eliminación da conta"
 
 #: src/view/com/modals/ChangeHandle.tsx:137
 msgid "Cancel change handle"
-msgstr "Cancelar troco do nome de usuario"
+msgstr "Cancelar cambio de alcume"
 
 #: src/view/com/modals/CropImage.web.tsx:94
 msgid "Cancel image crop"
-msgstr "Cancelar o recorte de imaxe"
-
-#: src/view/com/modals/EditProfile.tsx:239
-#~ msgid "Cancel profile editing"
-#~ msgstr "Cancelar edición do perfil"
+msgstr "Cancelar recorte de imaxe"
 
 #: src/view/com/util/post-ctrls/RepostButton.tsx:161
 msgid "Cancel quote post"
-msgstr "Cancelar citar publicación"
+msgstr "Cancelar citación"
 
 #: src/screens/Deactivated.tsx:155
 msgid "Cancel reactivation and log out"
-msgstr "Cancelar reactivación e saír"
+msgstr "Cancelar a reactivación e pechar a sesión"
 
 #: src/view/com/modals/ListAddRemoveUsers.tsx:88
 #: src/view/screens/Search/Search.tsx:902
 msgid "Cancel search"
-msgstr "Cancelar procura"
+msgstr "Cancelar búsqueda"
 
 #: src/view/com/modals/LinkWarning.tsx:106
 msgid "Cancels opening the linked website"
-msgstr "Cancelar a apertura do sitio web ligado"
+msgstr "Cancela apertura do sitio web vinculado"
 
 #: src/state/shell/composer/index.tsx:82
 #: src/view/com/util/post-ctrls/PostCtrls.tsx:113
 #: src/view/com/util/post-ctrls/PostCtrls.tsx:154
 #: src/view/com/util/post-ctrls/PostCtrls.tsx:190
 msgid "Cannot interact with a blocked user"
-msgstr "Non é posíbel interactuar cun usuario bloqueado"
+msgstr "Non se pode interactuar cunha conta bloqueada"
 
 #: src/view/com/composer/videos/SubtitleDialog.tsx:133
 msgid "Captions (.vtt)"
-msgstr "Subtítulos (.vtt)"
+msgstr "Lexendaxe (.vtt)"
 
 #: src/view/com/composer/videos/SubtitleDialog.tsx:56
 msgid "Captions & alt text"
-msgstr "Subtítulos e texto alternativo"
-
-#: src/components/dialogs/nuxs/TenMillion/index.tsx:368
-#~ msgid "Celebrating {0} users"
-#~ msgstr "Celebrando os {0} de usuarios"
+msgstr "Lexendaxe e texto alternativo"
 
 #: src/view/com/modals/VerifyEmail.tsx:160
 msgid "Change"
-msgstr "Mudar"
-
-#: src/view/screens/Settings/index.tsx:342
-msgctxt "action"
-msgid "Change"
-msgstr "Mudar"
+msgstr "Cambiar"
 
 #: src/components/dialogs/VerifyEmailDialog.tsx:147
 msgid "Change email address"
-msgstr "Mudar enderezo de correo"
+msgstr "Cambiar o enderezo electrónico"
 
 #: src/view/screens/Settings/index.tsx:685
 msgid "Change handle"
-msgstr "Mudar nome de usuario"
+msgstr "Cambiar alcume"
 
 #: src/view/com/modals/ChangeHandle.tsx:149
 #: src/view/screens/Settings/index.tsx:696
 msgid "Change Handle"
-msgstr "Mudar Nome de Usuario"
+msgstr "Cambiar alcume"
 
 #: src/view/com/modals/VerifyEmail.tsx:155
 msgid "Change my email"
-msgstr "Mudar o meu correo"
+msgstr "Cambiar o meu enderezo electrónico"
 
 #: src/view/screens/Settings/index.tsx:730
 msgid "Change password"
-msgstr "Mudar contrasinal"
+msgstr "Cambiar contrasinal"
 
 #: src/view/com/modals/ChangePassword.tsx:142
 #: src/view/screens/Settings/index.tsx:741
 msgid "Change Password"
-msgstr "Mudar Contrasinal"
+msgstr "Cambiar contrasinal"
 
 #: src/view/com/composer/select-language/SuggestedLanguage.tsx:73
 msgid "Change post language to {0}"
-msgstr "Mudar a lingua das publicacións a {0}"
+msgstr "Cambiar idioma do chío a {0}"
 
 #: src/view/com/modals/ChangeEmail.tsx:104
 msgid "Change Your Email"
-msgstr "Mudar o teu Correo"
+msgstr "Cambiar enderezo electrónico"
 
 #: src/Navigation.tsx:337
 #: src/view/shell/bottom-bar/BottomBar.tsx:200
 #: src/view/shell/desktop/LeftNav.tsx:329
 #: src/view/shell/Drawer.tsx:446
 msgid "Chat"
-msgstr "Conversa"
+msgstr "Chat"
 
 #: src/components/dms/ConvoMenu.tsx:82
 msgid "Chat muted"
-msgstr "Conversa silenciada"
+msgstr "Chat silenciado"
 
 #: src/components/dms/ConvoMenu.tsx:112
 #: src/components/dms/MessageMenu.tsx:81
@@ -1256,141 +1157,108 @@ msgstr "Axustes da conversa"
 #: src/screens/Messages/Settings.tsx:61
 #: src/view/screens/Settings/index.tsx:614
 msgid "Chat Settings"
-msgstr "Axustes da Conversa"
+msgstr "Configuración de conversa"
 
 #: src/components/dms/ConvoMenu.tsx:84
 msgid "Chat unmuted"
-msgstr "Conversa non silenciada"
+msgstr "Chat activado"
 
 #: src/screens/SignupQueued.tsx:78
 #: src/screens/SignupQueued.tsx:82
 msgid "Check my status"
-msgstr "Verificar o meu estado"
+msgstr "Verifica o meu estado"
 
 #: src/screens/Login/LoginForm.tsx:275
 msgid "Check your email for a login code and enter it here."
-msgstr "Comproba se tes un correo cun código de inicio de sesión e insíreo aquí."
+msgstr "Comproba o  código de comezo de sesión no teu correo e introdúceo aquí."
 
 #: src/view/com/modals/DeleteAccount.tsx:231
 msgid "Check your inbox for an email with the confirmation code to enter below:"
-msgstr "Procura na caixa de entrada un correo co código de confirmación a inserir aquí abaixo:"
-
-#: src/view/com/modals/Threadgate.tsx:75
-#~ msgid "Choose \"Everybody\" or \"Nobody\""
-#~ msgstr "Escolle \"Todos\" ou \"Ninguén\""
-
-#: src/screens/Onboarding/StepInterests/index.tsx:191
-#~ msgid "Choose 3 or more:"
-#~ msgstr "Escolle 3 ou máis"
-
-#: src/screens/Onboarding/StepInterests/index.tsx:326
-#~ msgid "Choose at least {0} more"
-#~ msgstr "Escolle polo menos {0} máis"
+msgstr "Enviamos un código de comezo de sesión ao teu correo. Introdúceo aquí:"
 
 #: src/screens/StarterPack/Wizard/index.tsx:199
 msgid "Choose Feeds"
-msgstr "Seleccionar fontes"
+msgstr "Escolle Canles"
 
 #: src/components/StarterPack/ProfileStarterPacks.tsx:291
 msgid "Choose for me"
-msgstr "Escoller para min"
+msgstr "Escolle para min"
 
 #: src/screens/StarterPack/Wizard/index.tsx:195
 msgid "Choose People"
-msgstr "Escoller á Xente"
+msgstr "Escolle xente"
 
 #: src/view/com/composer/labels/LabelsBtn.tsx:116
-msgid "Choose self-labels that are applicable for the media you are posting. If none are selected, this post is suitable for all audiences."
+msgid ""
+"Choose self-labels that are applicable for the media you are posting. If "
+"none are selected, this post is suitable for all audiences."
 msgstr ""
+"Elixe etiquetas propias que sexan aplicábeis ao medio no que estás chiando. "
+"Se non seleccionas ningunha, este chío é adecuado para todos os públicos."
 
 #: src/view/com/auth/server-input/index.tsx:76
 msgid "Choose Service"
-msgstr "Escoller servizo"
+msgstr "Escolle proveedor"
 
 #: src/screens/Onboarding/StepFinished.tsx:271
 msgid "Choose the algorithms that power your custom feeds."
-msgstr "Escoller os algoritmos que xeran as túas fontes personalizadas."
+msgstr "Ti elixes os algoritmos que usar nas túas canles."
 
 #: src/screens/Onboarding/StepProfile/AvatarCreatorItems.tsx:107
 msgid "Choose this color as your avatar"
-msgstr "Escoller esta cor para o teu avatar"
-
-#: src/components/dialogs/ThreadgateEditor.tsx:91
-#: src/components/dialogs/ThreadgateEditor.tsx:95
-#~ msgid "Choose who can reply"
-#~ msgstr "Escolle quen pode responder"
-
-#: src/screens/Onboarding/StepAlgoFeeds/index.tsx:104
-#~ msgid "Choose your main feeds"
-#~ msgstr "Escolle as túas fontes principais"
+msgstr "Elixe esta color como o teu avatar"
 
 #: src/screens/Signup/StepInfo/index.tsx:201
 msgid "Choose your password"
-msgstr "Escolle o teu contrasinal"
-
-#: src/view/screens/Settings/index.tsx:912
-#~ msgid "Clear all legacy storage data"
-#~ msgstr "Eliminar todos os datos do almacenamento herdado"
-
-#: src/view/screens/Settings/index.tsx:915
-#~ msgid "Clear all legacy storage data (restart after this)"
-#~ msgstr "Eliminar todos os datos do almacenamento herdado (reiniciar ao rematar)"
+msgstr "Escolleu o teu contrasinal"
 
 #: src/view/screens/Settings/index.tsx:877
 msgid "Clear all storage data"
-msgstr "Eliminar todos os datos de almacenamento"
+msgstr "Borrar todos os datos de almacenamento"
 
 #: src/view/screens/Settings/index.tsx:880
 msgid "Clear all storage data (restart after this)"
-msgstr "Eliminar todos os datos de almacenamento (reiniciar ao rematar)"
+msgstr "Borrar todos os datos de almacenamento (reiniciar despois disto)"
 
 #: src/components/forms/SearchInput.tsx:70
 msgid "Clear search query"
-msgstr "Limpar a procura"
-
-#: src/view/screens/Settings/index.tsx:913
-#~ msgid "Clears all legacy storage data"
-#~ msgstr "Elimina todos os datos de almacenamento"
+msgstr "Borrar consulta de búsqueda"
 
 #: src/view/screens/Settings/index.tsx:878
 msgid "Clears all storage data"
-msgstr "Elimina todos os datos"
+msgstr "Borrar todos os datos de almacenamento"
 
 #: src/view/screens/Support.tsx:41
 msgid "click here"
-msgstr "clic aquí"
+msgstr "Preme aquí"
 
 #: src/view/com/modals/DeleteAccount.tsx:208
 msgid "Click here for more information on deactivating your account"
-msgstr "Clic aquí para obter máis información sobre como desactivar a túa conta"
+msgstr "Preme aquí para obter máis información sobre a desactivación da túa conta"
 
 #: src/view/com/modals/DeleteAccount.tsx:216
 msgid "Click here for more information."
-msgstr "Clic aquí para obter máis información."
-
-#: src/screens/Feeds/NoFollowingFeed.tsx:46
-#~ msgid "Click here to add one."
-#~ msgstr "Clic aquí para engadir un."
+msgstr "Preme aquí para obter máis información."
 
 #: src/components/TagMenu/index.web.tsx:152
 msgid "Click here to open tag menu for {tag}"
-msgstr "Clic aquí para abrir o menú de etiquetas para {tag}"
+msgstr "Preme aquí para abrir o menú de {tag}"
 
 #: src/components/dialogs/PostInteractionSettingsDialog.tsx:304
 msgid "Click to disable quote posts of this post."
-msgstr "Clic para deshabilitar as citas nesta publicación."
+msgstr "Preme para deshabilitar as citas para este chío."
 
 #: src/components/dialogs/PostInteractionSettingsDialog.tsx:305
 msgid "Click to enable quote posts of this post."
-msgstr "Clic para habilitar as citas nesta publicación."
+msgstr "Preme para habilitar as citas para este chío."
 
 #: src/components/dms/MessageItem.tsx:240
 msgid "Click to retry failed message"
-msgstr "Clic para tentar enviar a mensaxe de novo"
+msgstr "Preme para reintentar a mensaxe fallida"
 
 #: src/screens/Onboarding/index.tsx:32
 msgid "Climate"
-msgstr "Meteoroloxía"
+msgstr "Clima"
 
 #: src/components/dms/ChatEmptyPill.tsx:39
 msgid "Clip 🐴 clop 🐴"
@@ -1412,7 +1280,7 @@ msgstr "Pechar"
 #: src/components/Dialog/index.web.tsx:110
 #: src/components/Dialog/index.web.tsx:256
 msgid "Close active dialog"
-msgstr "Pechar diálogo activo"
+msgstr "Pechar xanela activa"
 
 #: src/screens/Login/PasswordUpdatedForm.tsx:32
 msgid "Close alert"
@@ -1420,15 +1288,15 @@ msgstr "Pechar alerta"
 
 #: src/view/com/util/BottomSheetCustomBackdrop.tsx:36
 msgid "Close bottom drawer"
-msgstr "Pechar parte inferior"
+msgstr "Pechar o caixón inferior"
 
 #: src/components/dialogs/GifSelect.tsx:276
 msgid "Close dialog"
-msgstr "Pechar diálogo"
+msgstr "Pechar"
 
 #: src/components/dialogs/GifSelect.tsx:169
 msgid "Close GIF dialog"
-msgstr "Pechar diálogo de GIFs"
+msgstr "Pechar caixa de GIF"
 
 #: src/view/com/lightbox/ImageViewing/components/ImageDefaultHeader.tsx:36
 msgid "Close image"
@@ -1436,20 +1304,16 @@ msgstr "Pechar imaxe"
 
 #: src/view/com/lightbox/Lightbox.web.tsx:129
 msgid "Close image viewer"
-msgstr "Pechar visor de imaxes"
-
-#: src/components/dms/MessagesNUX.tsx:162
-#~ msgid "Close modal"
-#~ msgstr "Pechar a modal"
+msgstr "Pechar o visor de imaxes"
 
 #: src/view/shell/index.web.tsx:67
 msgid "Close navigation footer"
-msgstr "Pechar panel de navegación"
+msgstr "Pechar pé de páxina"
 
 #: src/components/Menu/index.tsx:229
 #: src/components/TagMenu/index.tsx:261
 msgid "Close this dialog"
-msgstr "Pechar este diálogo"
+msgstr "Pechar esta xanela"
 
 #: src/view/shell/index.web.tsx:68
 msgid "Closes bottom navigation bar"
@@ -1457,27 +1321,23 @@ msgstr "Pecha a barra de navegación inferior"
 
 #: src/screens/Login/PasswordUpdatedForm.tsx:33
 msgid "Closes password update alert"
-msgstr "Pecha o aviso de actualización do contrasinal"
-
-#: src/view/com/composer/Composer.tsx:552
-#~ msgid "Closes post composer and discards post draft"
-#~ msgstr "Pecha o editor de publicacións e desbota"
+msgstr "Pecha a alerta de actualización de contrasinal"
 
 #: src/view/com/lightbox/ImageViewing/components/ImageDefaultHeader.tsx:37
 msgid "Closes viewer for header image"
-msgstr "Pecha o visor da imaxe de cabeceira"
+msgstr "Pecha o visor do encabezado da imaxe"
 
 #: src/view/com/notifications/FeedItem.tsx:265
 msgid "Collapse list of users"
-msgstr "Contraer lista de usuarios"
+msgstr "Pechar listaxe de contas"
 
 #: src/view/com/notifications/FeedItem.tsx:470
 msgid "Collapses list of users for a given notification"
-msgstr "Contrae a lista de usuarios para unha notificación"
+msgstr "Pechar a listaxe de contas para unha notificación en particular"
 
 #: src/screens/Settings/AppearanceSettings.tsx:97
 msgid "Color mode"
-msgstr "Esquema de cor"
+msgstr "Modo de color"
 
 #: src/screens/Onboarding/index.tsx:38
 #: src/screens/Onboarding/state.ts:84
@@ -1487,7 +1347,7 @@ msgstr "Comedia"
 #: src/screens/Onboarding/index.tsx:24
 #: src/screens/Onboarding/state.ts:85
 msgid "Comics"
-msgstr "Banda deseñada"
+msgstr "Bandas deseñadas"
 
 #: src/Navigation.tsx:275
 #: src/view/screens/CommunityGuidelines.tsx:34
@@ -1496,39 +1356,31 @@ msgstr "Directrices da comunidade"
 
 #: src/screens/Onboarding/StepFinished.tsx:284
 msgid "Complete onboarding and start using your account"
-msgstr "Completar a benvida e comezar a usar a túa conta"
+msgstr "Completa a incorporación e comeza a usar a túa conta"
 
 #: src/screens/Signup/index.tsx:144
 msgid "Complete the challenge"
-msgstr "Completa o obxectivo"
+msgstr "Completa o desafío"
 
 #: src/view/com/composer/Composer.tsx:632
 msgid "Compose posts up to {MAX_GRAPHEME_LENGTH} characters in length"
-msgstr "Escribe publicacións de até {MAX_GRAPHEME_LENGTH} caracteres"
+msgstr "Compoñer chíos até {MAX_GRAPHEME_LENGTH} caracteres de lonxitude"
 
 #: src/view/com/post-thread/PostThreadComposePrompt.tsx:35
 msgid "Compose reply"
-msgstr "Compoñer resposta"
+msgstr "Redactar resposta"
 
 #: src/view/com/composer/Composer.tsx:1341
 msgid "Compressing video..."
 msgstr "Comprimindo vídeo..."
 
-#: src/view/com/composer/videos/VideoTranscodeProgress.tsx:51
-#~ msgid "Compressing..."
-#~ msgstr "Comprimindo..."
-
-#: src/screens/Onboarding/StepModeration/ModerationOption.tsx:81
-#~ msgid "Configure content filtering setting for category: {0}"
-#~ msgstr "Configura o axuste de filtrado de contido para a categoría: {0}"
-
 #: src/components/moderation/LabelPreference.tsx:81
 msgid "Configure content filtering setting for category: {name}"
-msgstr "Configura o axuste de filtrado de contido para a categoría: {name}"
+msgstr "Configuración de filtrado de contido para a categoría: {name}"
 
 #: src/components/moderation/LabelPreference.tsx:243
 msgid "Configured in <0>moderation settings</0>."
-msgstr "Configurado nos <0>axustes de moderación</0>."
+msgstr "Configurado en <0>axustes de moderación</0>"
 
 #: src/components/dialogs/VerifyEmailDialog.tsx:210
 #: src/components/dialogs/VerifyEmailDialog.tsx:217
@@ -1545,11 +1397,11 @@ msgstr "Confirmar"
 #: src/view/com/modals/ChangeEmail.tsx:188
 #: src/view/com/modals/ChangeEmail.tsx:190
 msgid "Confirm Change"
-msgstr "Confirmar troco"
+msgstr "Confirmar o cambio"
 
 #: src/view/com/modals/lang-settings/ConfirmLanguagesButton.tsx:35
 msgid "Confirm content language settings"
-msgstr "Confirmar axustes"
+msgstr "Confimar o idioma do contido"
 
 #: src/view/com/modals/DeleteAccount.tsx:282
 msgid "Confirm delete account"
@@ -1557,7 +1409,7 @@ msgstr "Confirmar eliminación da conta"
 
 #: src/screens/Moderation/index.tsx:314
 msgid "Confirm your age:"
-msgstr "Confirmar a túa idade:"
+msgstr "Confirma a túa idade:"
 
 #: src/screens/Moderation/index.tsx:305
 msgid "Confirm your birthdate"
@@ -1572,11 +1424,11 @@ msgstr "Confirma a túa data de nacemento"
 #: src/view/screens/Settings/DisableEmail2FADialog.tsx:142
 #: src/view/screens/Settings/DisableEmail2FADialog.tsx:148
 msgid "Confirmation code"
-msgstr "Código de confirmanción"
+msgstr "Código de confirmación"
 
 #: src/components/dialogs/VerifyEmailDialog.tsx:167
 msgid "Confirmation Code"
-msgstr "Código de Confirmación"
+msgstr "Código de confirmación"
 
 #: src/screens/Login/LoginForm.tsx:309
 msgid "Connecting..."
@@ -1585,11 +1437,7 @@ msgstr "Conectando..."
 #: src/screens/Signup/index.tsx:175
 #: src/screens/Signup/index.tsx:178
 msgid "Contact support"
-msgstr "Contactar co soporte"
-
-#: src/components/moderation/LabelsOnMe.tsx:42
-#~ msgid "content"
-#~ msgstr "contido"
+msgstr "Contacta co soporte"
 
 #: src/lib/moderation/useGlobalLabelStrings.ts:18
 msgid "Content Blocked"
@@ -1602,7 +1450,7 @@ msgstr "Filtros de contido"
 #: src/view/com/modals/lang-settings/ContentLanguagesSettings.tsx:75
 #: src/view/screens/LanguageSettings.tsx:280
 msgid "Content Languages"
-msgstr "Linguas do contido"
+msgstr "Idiomas de contido"
 
 #: src/components/moderation/ModerationDetailsDialog.tsx:81
 #: src/lib/moderation/useModerationCauseDescription.ts:80
@@ -1614,15 +1462,15 @@ msgstr "Contido non dispoñíbel"
 #: src/lib/moderation/useGlobalLabelStrings.ts:22
 #: src/lib/moderation/useModerationCauseDescription.ts:43
 msgid "Content Warning"
-msgstr "Aviso de contido"
+msgstr "Advertencia de contido"
 
 #: src/view/com/composer/labels/LabelsBtn.tsx:61
 msgid "Content warnings"
-msgstr "Avisos de contido"
+msgstr "Advertencia de contido"
 
 #: src/components/Menu/index.web.tsx:83
 msgid "Context menu backdrop, click to close the menu."
-msgstr "Fondo do menú, clic para pecha-lo menú."
+msgstr "Fondo do menú contextual, preme para pechar o menú."
 
 #: src/screens/Onboarding/StepInterests/index.tsx:244
 #: src/screens/Onboarding/StepProfile/index.tsx:278
@@ -1631,25 +1479,17 @@ msgstr "Continuar"
 
 #: src/components/AccountList.tsx:121
 msgid "Continue as {0} (currently signed in)"
-msgstr "Continuar como {0} (xa conectado)"
+msgstr "Continuar como {0} (actualmente iniciaches sesión)"
 
 #: src/view/com/post-thread/PostThreadLoadMore.tsx:52
 msgid "Continue thread..."
-msgstr "Continuar o fío..."
+msgstr "Continuar fío..."
 
 #: src/screens/Onboarding/StepInterests/index.tsx:241
 #: src/screens/Onboarding/StepProfile/index.tsx:275
 #: src/screens/Signup/BackNextButtons.tsx:61
 msgid "Continue to next step"
-msgstr "Continuar no seguinte paso"
-
-#: src/screens/Onboarding/StepAlgoFeeds/index.tsx:158
-#~ msgid "Continue to the next step"
-#~ msgstr "Continuar no seguinte paso"
-
-#: src/screens/Onboarding/StepSuggestedAccounts/index.tsx:199
-#~ msgid "Continue to the next step without following any accounts"
-#~ msgstr "Continuar no seguinte paso sen seguir ningunha conta"
+msgstr "Sigue co seguinte paso"
 
 #: src/screens/Messages/components/ChatListItem.tsx:164
 msgid "Conversation deleted"
@@ -1657,7 +1497,7 @@ msgstr "Conversa eliminada"
 
 #: src/screens/Onboarding/index.tsx:41
 msgid "Cooking"
-msgstr "Cociña"
+msgstr "Cociñando"
 
 #: src/view/com/modals/AddAppPasswords.tsx:221
 #: src/view/com/modals/InviteCodes.tsx:183
@@ -1666,7 +1506,7 @@ msgstr "Copiado"
 
 #: src/view/screens/Settings/index.tsx:234
 msgid "Copied build version to clipboard"
-msgstr "Versión copiada ao portapapeis"
+msgstr "Versión de compilación copiada ao portapapeis"
 
 #: src/components/dms/MessageMenu.tsx:57
 #: src/lib/sharing.ts:25
@@ -1684,7 +1524,7 @@ msgstr "Copiado!"
 
 #: src/view/com/modals/AddAppPasswords.tsx:215
 msgid "Copies app password"
-msgstr "Copia o contrasinal"
+msgstr "Copia o contrasinal da aplicación"
 
 #: src/components/StarterPack/QrCodeDialog.tsx:175
 #: src/view/com/modals/AddAppPasswords.tsx:214
@@ -1693,7 +1533,7 @@ msgstr "Copiar"
 
 #: src/view/com/modals/ChangeHandle.tsx:467
 msgid "Copy {0}"
-msgstr "Copiar{0}"
+msgstr "Copiar {0}"
 
 #: src/components/dialogs/Embed.tsx:122
 #: src/components/dialogs/Embed.tsx:141
@@ -1710,12 +1550,12 @@ msgstr "Copiar Ligazón"
 
 #: src/view/screens/ProfileList.tsx:487
 msgid "Copy link to list"
-msgstr "Copiar ligazón na lista"
+msgstr "Copia ligazón á lista"
 
 #: src/view/com/util/forms/PostDropdownBtn.tsx:452
 #: src/view/com/util/forms/PostDropdownBtn.tsx:461
 msgid "Copy link to post"
-msgstr "Copiar ligazón na publicación"
+msgstr "Copiar ligazón ao chío"
 
 #: src/components/dms/MessageMenu.tsx:110
 #: src/components/dms/MessageMenu.tsx:112
@@ -1725,7 +1565,7 @@ msgstr "Copiar texto da mensaxe"
 #: src/view/com/util/forms/PostDropdownBtn.tsx:430
 #: src/view/com/util/forms/PostDropdownBtn.tsx:432
 msgid "Copy post text"
-msgstr "Copiar o texto da publicación"
+msgstr "Copiar texto do chío"
 
 #: src/components/StarterPack/QrCodeDialog.tsx:169
 msgid "Copy QR code"
@@ -1734,52 +1574,35 @@ msgstr "Copiar código QR"
 #: src/Navigation.tsx:280
 #: src/view/screens/CopyrightPolicy.tsx:31
 msgid "Copyright Policy"
-msgstr "Política de Copyright"
-
-#: src/view/com/composer/videos/state.ts:31
-#~ msgid "Could not compress video"
-#~ msgstr "Non foi posíbel comprimir o vídeo"
+msgstr "Política de dereitos de autor"
 
 #: src/components/dms/LeaveConvoPrompt.tsx:39
 msgid "Could not leave chat"
-msgstr "Non foi posíbel saír da conversa"
+msgstr "Non se puido saír deste conversa"
 
 #: src/view/screens/ProfileFeed.tsx:104
 msgid "Could not load feed"
-msgstr "Non foi posíbel cargar a fonte"
+msgstr "Non se puido cargar esta canle"
 
 #: src/view/screens/ProfileList.tsx:1020
 msgid "Could not load list"
-msgstr "Non foi posíbel cargar a lista"
-
-#: src/components/dms/NewChat.tsx:241
-#~ msgid "Could not load profiles. Please try again later."
-#~ msgstr "Non foi posíbel cargar os perfís. Téntao más tarde."
+msgstr "Non se puido cargar esta listaxe"
 
 #: src/components/dms/ConvoMenu.tsx:88
 msgid "Could not mute chat"
-msgstr "Non foi posíbel silenciar a conversa"
+msgstr "Non se puido silenciar a conversa"
 
 #: src/view/com/composer/videos/VideoPreview.web.tsx:56
 msgid "Could not process your video"
-msgstr "Non foi posíbel procesar o teu vídeo"
-
-#: src/components/dms/ConvoMenu.tsx:68
-#~ msgid "Could not unmute chat"
-#~ msgstr "Non foi posíbel desenmudecer a conversa"
+msgstr "Non se puido procesar o teu vídeo"
 
 #: src/components/StarterPack/ProfileStarterPacks.tsx:273
 msgid "Create"
 msgstr "Crear"
 
-#: src/view/com/auth/SplashScreen.tsx:57
-#: src/view/com/auth/SplashScreen.web.tsx:106
-#~ msgid "Create a new account"
-#~ msgstr "Crear unha conta nova"
-
 #: src/view/screens/Settings/index.tsx:403
 msgid "Create a new Bluesky account"
-msgstr "Crear unha nova conta no Bluesky"
+msgstr "Crear unha conta nova de Bluesky"
 
 #: src/components/StarterPack/QrCodeDialog.tsx:153
 msgid "Create a QR code for a starter pack"
@@ -1789,50 +1612,46 @@ msgstr "Crear un código QR para o paquete de inicio"
 #: src/components/StarterPack/ProfileStarterPacks.tsx:260
 #: src/Navigation.tsx:367
 msgid "Create a starter pack"
-msgstr "Crear un paquete de inicio"
+msgstr "Crea un paquete de inicio"
 
 #: src/components/StarterPack/ProfileStarterPacks.tsx:247
 msgid "Create a starter pack for me"
-msgstr "Crear un paquete de inicio para min"
+msgstr "Crea un paquete de inicio para min"
 
 #: src/view/com/auth/SplashScreen.tsx:56
 #: src/view/com/auth/SplashScreen.web.tsx:116
 msgid "Create account"
-msgstr "Crear conta"
+msgstr "Crear unha conta"
 
 #: src/screens/Signup/index.tsx:93
 msgid "Create Account"
-msgstr "Crear Conta"
+msgstr "Crear unha conta"
 
 #: src/components/dialogs/Signin.tsx:86
 #: src/components/dialogs/Signin.tsx:88
 msgid "Create an account"
-msgstr "Crear unha conta"
+msgstr "Crea unha conta"
 
 #: src/screens/Onboarding/StepProfile/index.tsx:292
 msgid "Create an avatar instead"
-msgstr "Crear un avatar no seu lugar"
+msgstr "Crea un avatar"
 
 #: src/components/StarterPack/ProfileStarterPacks.tsx:173
 msgid "Create another"
-msgstr "Crear outro"
+msgstr "Crea outro"
 
 #: src/view/com/modals/AddAppPasswords.tsx:243
 msgid "Create App Password"
-msgstr "Definir o contrasinal"
+msgstr "Crea un contrasinal de aplicación"
 
 #: src/view/com/auth/SplashScreen.tsx:48
 #: src/view/com/auth/SplashScreen.web.tsx:108
 msgid "Create new account"
-msgstr "Crear nova conta"
-
-#: src/components/StarterPack/ShareDialog.tsx:158
-#~ msgid "Create QR code"
-#~ msgstr "Crea un código QR"
+msgstr "Crear unha conta nova"
 
 #: src/components/ReportDialog/SelectReportOptionView.tsx:101
 msgid "Create report for {0}"
-msgstr "Crear informe para {0}"
+msgstr "Crea un reporte de {0}"
 
 #: src/view/screens/AppPasswords.tsx:252
 msgid "Created {0}"
@@ -1854,16 +1673,20 @@ msgstr "Dominio personalizado"
 
 #: src/view/screens/Feeds.tsx:761
 #: src/view/screens/Search/Explore.tsx:391
-msgid "Custom feeds built by the community bring you new experiences and help you find the content you love."
-msgstr "As fontes personalizadas pola comunidade fornecen de novas experiencias e axúdanche a atopar o contido que che gusta."
+msgid ""
+"Custom feeds built by the community bring you new experiences and help you "
+"find the content you love."
+msgstr ""
+"Os fíos personalizados creados pola comunidade brindan canles de "
+"experiencias e axúdanche a encontrar o contido que queres."
 
 #: src/view/screens/PreferencesExternalEmbeds.tsx:54
 msgid "Customize media from external sites."
-msgstr "Personalizar os media de sitios externos."
+msgstr "Preferencias sobre medios externos."
 
 #: src/components/dialogs/PostInteractionSettingsDialog.tsx:289
 msgid "Customize who can interact with this post."
-msgstr "Personalizar quen pode interactuar con esta publicación."
+msgstr "Personaliza quen pode interactuar con este chío."
 
 #: src/screens/Settings/AppearanceSettings.tsx:109
 #: src/screens/Settings/AppearanceSettings.tsx:130
@@ -1872,15 +1695,11 @@ msgstr "Escuro"
 
 #: src/view/screens/Debug.tsx:70
 msgid "Dark mode"
-msgstr "Modo escuro"
+msgstr "Modo Escuro"
 
 #: src/screens/Settings/AppearanceSettings.tsx:122
 msgid "Dark theme"
 msgstr "Tema escuro"
-
-#: src/view/screens/Settings/index.tsx:473
-#~ msgid "Dark Theme"
-#~ msgstr "Tema escuro"
 
 #: src/screens/Signup/StepInfo/index.tsx:222
 msgid "Date of birth"
@@ -1897,7 +1716,7 @@ msgstr "Desactivar a miña conta"
 
 #: src/view/screens/Settings/index.tsx:840
 msgid "Debug Moderation"
-msgstr "Depurar moderación"
+msgstr "Depuración de Moderacion"
 
 #: src/view/screens/Debug.tsx:90
 msgid "Debug panel"
@@ -1906,7 +1725,7 @@ msgstr "Panel de depuración"
 #: src/components/dialogs/nuxs/NeueTypography.tsx:99
 #: src/screens/Settings/AppearanceSettings.tsx:169
 msgid "Default"
-msgstr "Predefinida"
+msgstr "Por Defecto"
 
 #: src/components/dms/MessageMenu.tsx:151
 #: src/screens/StarterPack/StarterPackScreen.tsx:584
@@ -1916,90 +1735,86 @@ msgstr "Predefinida"
 #: src/view/screens/AppPasswords.tsx:286
 #: src/view/screens/ProfileList.tsx:726
 msgid "Delete"
-msgstr "Eliminar"
+msgstr "Borrar"
 
 #: src/view/screens/Settings/index.tsx:795
 msgid "Delete account"
-msgstr "Eliminar conta"
-
-#: src/view/com/modals/DeleteAccount.tsx:87
-#~ msgid "Delete Account"
-#~ msgstr "Eliminar a conta"
+msgstr "Borrar a conta"
 
 #: src/view/com/modals/DeleteAccount.tsx:105
 msgid "Delete Account <0>\"</0><1>{0}</1><2>\"</2>"
-msgstr "Eliminar Conta <0>\"</0><1>{0}</1><2>\"</2>"
+msgstr "Borrar a conta <0>\"</0><1>{0}</1><2>\"</2>"
 
 #: src/view/screens/AppPasswords.tsx:245
 msgid "Delete app password"
-msgstr "Eliminar contrasinal da aplicación"
+msgstr "Borrar contrasinal de aplicación"
 
 #: src/view/screens/AppPasswords.tsx:281
 msgid "Delete app password?"
-msgstr "Eliminar o contrasinal da aplicación?"
+msgstr "Borrar contrasinal de aplicación?"
 
 #: src/view/screens/Settings/index.tsx:857
 #: src/view/screens/Settings/index.tsx:860
 msgid "Delete chat declaration record"
-msgstr ""
+msgstr "Eliminar rexistro de declaración de conversa"
 
 #: src/components/dms/MessageMenu.tsx:124
 msgid "Delete for me"
-msgstr "Eliminar para min"
+msgstr "Borrar para min"
 
 #: src/view/screens/ProfileList.tsx:530
 msgid "Delete List"
-msgstr "Eliminar Lista"
+msgstr "Borrar a listaxe"
 
 #: src/components/dms/MessageMenu.tsx:147
 msgid "Delete message"
-msgstr "Eliminar mensaxe"
+msgstr "Borrar mensaxe"
 
 #: src/components/dms/MessageMenu.tsx:122
 msgid "Delete message for me"
-msgstr "Eliminar mensaxe para min"
+msgstr "Borrar mensaxe para min"
 
 #: src/view/com/modals/DeleteAccount.tsx:285
 msgid "Delete my account"
-msgstr "Eliminar a miña conta"
+msgstr "Borrar a miña conta"
 
 #: src/view/screens/Settings/index.tsx:807
 msgid "Delete My Account…"
-msgstr "Eliminar a miña Conta…"
+msgstr "Borrar A Miña Conta…"
 
 #: src/view/com/util/forms/PostDropdownBtn.tsx:653
 #: src/view/com/util/forms/PostDropdownBtn.tsx:655
 msgid "Delete post"
-msgstr "Eliminar publicación"
+msgstr "Borrar un chío"
 
 #: src/screens/StarterPack/StarterPackScreen.tsx:578
 #: src/screens/StarterPack/StarterPackScreen.tsx:734
 msgid "Delete starter pack"
-msgstr "Eliminar paquete de inicio"
+msgstr "Borrar paquete de inicio"
 
 #: src/screens/StarterPack/StarterPackScreen.tsx:629
 msgid "Delete starter pack?"
-msgstr "Eliminar o paquete de inicio?"
+msgstr "Borrar paquete de inicio?"
 
 #: src/view/screens/ProfileList.tsx:721
 msgid "Delete this list?"
-msgstr "Eliminar esta lista?"
+msgstr "Borrar esta listaxe?"
 
 #: src/view/com/util/forms/PostDropdownBtn.tsx:668
 msgid "Delete this post?"
-msgstr "Eliminar esta publicación?"
+msgstr "Borrar este chío?"
 
 #: src/view/com/util/post-embeds/QuoteEmbed.tsx:92
 msgid "Deleted"
-msgstr "Eliminada"
+msgstr "Eliminado"
 
 #: src/view/com/post-thread/PostThread.tsx:398
 msgid "Deleted post."
-msgstr "Publicación eliminada."
+msgstr "Borrouse o chío."
 
 #: src/view/screens/Settings/index.tsx:858
 msgid "Deletes the chat declaration record"
-msgstr ""
+msgstr "Elimina o rexistro de declaración de conversa"
 
 #: src/screens/Profile/Header/EditProfileDialog.tsx:344
 #: src/view/com/modals/CreateOrEditList.tsx:280
@@ -2009,11 +1824,15 @@ msgstr "Descrición"
 
 #: src/screens/Profile/Header/EditProfileDialog.tsx:364
 msgid "Description is too long"
-msgstr "Descrición longa de máis"
+msgstr "A descrición é demasiado longa"
 
 #: src/screens/Profile/Header/EditProfileDialog.tsx:365
-msgid "Description is too long. The maximum number of characters is {DESCRIPTION_MAX_GRAPHEMES}."
-msgstr "A descrición é longa de máis. O número máximo de caracteres é {DESCRIPTION_MAX_GRAPHEMES}."
+msgid ""
+"Description is too long. The maximum number of characters is "
+"{DESCRIPTION_MAX_GRAPHEMES}."
+msgstr ""
+"A descrición é demasiado longa. O máximo son {DESCRIPTION_MAX_GRAPHEMES} "
+"caracteres."
 
 #: src/view/com/composer/GifAltText.tsx:150
 #: src/view/com/composer/photos/ImageAltTextDialog.tsx:114
@@ -2023,47 +1842,39 @@ msgstr "Texto descritivo alternativo"
 #: src/view/com/util/forms/PostDropdownBtn.tsx:586
 #: src/view/com/util/forms/PostDropdownBtn.tsx:596
 msgid "Detach quote"
-msgstr "Desfixar cita"
+msgstr "Desvincular cita"
 
 #: src/view/com/util/forms/PostDropdownBtn.tsx:731
 msgid "Detach quote post?"
-msgstr ""
+msgstr "Desvincular chío da cita?"
 
 #: src/components/WhoCanReply.tsx:175
 msgid "Dialog: adjust who can interact with this post"
-msgstr "Diálogo: configura quen pode interactuar con esta publicación."
+msgstr "Xanela: axustar quen pode interactuar con este chío"
 
 #: src/view/com/composer/Composer.tsx:325
 msgid "Did you want to say anything?"
-msgstr "Desexas dicir algo?"
+msgstr "Queres decir algo?"
 
 #: src/screens/Settings/AppearanceSettings.tsx:126
 msgid "Dim"
-msgstr "Escurecer"
-
-#: src/components/dms/MessagesNUX.tsx:88
-#~ msgid "Direct messages are here!"
-#~ msgstr "As mensaxes directas están aquí!"
-
-#: src/view/screens/AccessibilitySettings.tsx:111
-#~ msgid "Disable autoplay for GIFs"
-#~ msgstr "Deshabilita a reprodución automática de GIFs"
+msgstr ""
 
 #: src/view/screens/AccessibilitySettings.tsx:109
 msgid "Disable autoplay for videos and GIFs"
-msgstr "Desactivar a reprodución automática para vídeos e GIFs"
+msgstr "Desactivar a reproducción automática de vídeos e GIFs"
 
 #: src/view/screens/Settings/DisableEmail2FADialog.tsx:89
 msgid "Disable Email 2FA"
-msgstr "Deshabilitar correo 2FA"
+msgstr "Desactivar Correo 2FA"
 
 #: src/view/screens/AccessibilitySettings.tsx:123
 msgid "Disable haptic feedback"
-msgstr ""
+msgstr "Desactivar a retroalimentación háptica"
 
 #: src/view/com/util/post-embeds/VideoEmbedInner/web-controls/VideoControls.tsx:388
 msgid "Disable subtitles"
-msgstr "Deshabilitar subtítulos"
+msgstr "Desactivar lexendaxe"
 
 #: src/lib/moderation/useLabelBehaviorDescription.ts:32
 #: src/lib/moderation/useLabelBehaviorDescription.ts:42
@@ -2072,7 +1883,7 @@ msgstr "Deshabilitar subtítulos"
 #: src/screens/Messages/Settings.tsx:136
 #: src/screens/Moderation/index.tsx:356
 msgid "Disabled"
-msgstr "Deshabilitada"
+msgstr "Deshabilitado"
 
 #: src/screens/Profile/Header/EditProfileDialog.tsx:84
 #: src/view/com/composer/Composer.tsx:534
@@ -2081,33 +1892,29 @@ msgstr "Desbotar"
 
 #: src/screens/Profile/Header/EditProfileDialog.tsx:81
 msgid "Discard changes?"
-msgstr "Desbotar trocos?"
+msgstr "Desbotar cambios?"
 
 #: src/view/com/composer/Composer.tsx:531
 msgid "Discard draft?"
-msgstr "Desbotar esbozos?"
+msgstr "Desbotar borrador?"
 
 #: src/screens/Moderation/index.tsx:556
 #: src/screens/Moderation/index.tsx:560
 msgid "Discourage apps from showing my account to logged-out users"
-msgstr "Evitar que as aplicacións amosen a miña conta a usuario desconectados"
-
-#: src/tours/HomeTour.tsx:70
-#~ msgid "Discover learns which posts you like as you browse."
-#~ msgstr ""
+msgstr "Evitar que as aplicacións amosen a miña conta ás persoas desconectadas"
 
 #: src/view/com/posts/FollowingEmptyState.tsx:70
 #: src/view/com/posts/FollowingEndOfFeed.tsx:71
 msgid "Discover new custom feeds"
-msgstr "Descubrir novas fontes personalizadas"
+msgstr "Descubre novas canles personalizadas"
 
 #: src/view/screens/Search/Explore.tsx:389
 msgid "Discover new feeds"
-msgstr "Descubrir novas fontes"
+msgstr "Descobre novas canles"
 
 #: src/view/screens/Feeds.tsx:758
 msgid "Discover New Feeds"
-msgstr "Descubrir Novas Fontes"
+msgstr "Descobre Novas Canles"
 
 #: src/components/Dialog/index.tsx:315
 msgid "Dismiss"
@@ -2119,57 +1926,57 @@ msgstr "Desbotar erro"
 
 #: src/components/ProgressGuide/List.tsx:40
 msgid "Dismiss getting started guide"
-msgstr "Omitir a guía de inicio"
+msgstr "Desbotar a guía de introdución"
 
 #: src/view/screens/AccessibilitySettings.tsx:97
 msgid "Display larger alt text badges"
-msgstr "Amosar insignias de texto alternativo máis longo"
+msgstr "Amosar insignias de texto alternativo máis grandes"
 
 #: src/screens/Profile/Header/EditProfileDialog.tsx:314
 #: src/screens/Profile/Header/EditProfileDialog.tsx:320
 #: src/screens/Profile/Header/EditProfileDialog.tsx:351
 msgid "Display name"
-msgstr "Amosar nome"
-
-#: src/view/com/modals/EditProfile.tsx:175
-#~ msgid "Display Name"
-#~ msgstr "Amosar Nome"
+msgstr "Amosar o nome"
 
 #: src/screens/Profile/Header/EditProfileDialog.tsx:333
 msgid "Display name is too long"
-msgstr "O nome para amosar e longo de máis"
+msgstr "O nome amosado é demasiado longo"
 
 #: src/screens/Profile/Header/EditProfileDialog.tsx:334
-msgid "Display name is too long. The maximum number of characters is {DISPLAY_NAME_MAX_GRAPHEMES}."
-msgstr "O nome para amosar e longo de máis. O número máximo de caracteres é {DISPLAY_NAME_MAX_GRAPHEMES}"
+msgid ""
+"Display name is too long. The maximum number of characters is "
+"{DISPLAY_NAME_MAX_GRAPHEMES}."
+msgstr ""
+"O nome amosado é demasiado longo. O máximo son {DISPLAY_NAME_MAX_GRAPHEMES} "
+"caracteres."
 
 #: src/view/com/modals/ChangeHandle.tsx:384
 msgid "DNS Panel"
-msgstr "Panel DNS"
+msgstr "Panel de DNS"
 
 #: src/components/dialogs/MutedWords.tsx:302
 msgid "Do not apply this mute word to users you follow"
-msgstr "Non aplicar esta palabra silenciada aos usuarios que segues"
+msgstr "Non aplicar esta palabra silenciada ás persoas que segues"
 
 #: src/view/com/composer/labels/LabelsBtn.tsx:174
 msgid "Does not contain adult content."
-msgstr "Non contén contido para adultos."
+msgstr "Non contén contido para persoas adultas."
 
 #: src/view/com/composer/labels/LabelsBtn.tsx:213
 msgid "Does not contain graphic or disturbing content."
-msgstr "Non contén contido gráfico ou perturbador."
+msgstr "Non contén imaxes ou contido perturbador."
 
 #: src/lib/moderation/useGlobalLabelStrings.ts:39
 msgid "Does not include nudity."
-msgstr "Non inclúe nudez."
+msgstr "Non inclúe espidos."
 
 #: src/screens/Signup/StepHandle.tsx:159
 msgid "Doesn't begin or end with a hyphen"
-msgstr "Non comeza ou remata cun guión"
+msgstr "Non comeza nin remata cun guión."
 
 #: src/view/com/modals/ChangeHandle.tsx:468
 msgid "Domain Value"
-msgstr "Valor de dominio"
+msgstr "Valor do dominio"
 
 #: src/view/com/modals/ChangeHandle.tsx:475
 msgid "Domain verified!"
@@ -2193,22 +2000,15 @@ msgstr "Dominio verificado!"
 #: src/view/com/modals/InviteCodes.tsx:124
 #: src/view/com/modals/ListAddRemoveUsers.tsx:143
 msgid "Done"
-msgstr "Feito"
-
-#: src/view/com/modals/ListAddRemoveUsers.tsx:145
-#: src/view/com/modals/UserAddRemoveLists.tsx:113
-#: src/view/com/modals/UserAddRemoveLists.tsx:116
-msgctxt "action"
-msgid "Done"
-msgstr "Feito"
+msgstr "Listo"
 
 #: src/view/com/modals/lang-settings/ConfirmLanguagesButton.tsx:43
 msgid "Done{extraText}"
-msgstr "Feito{extraText}"
+msgstr "Listo{extraText}"
 
 #: src/components/Dialog/index.tsx:316
 msgid "Double tap to close the dialog"
-msgstr "Duplo toque para pechar o diálogo"
+msgstr "Doble toque para pechar a xanela"
 
 #: src/screens/StarterPack/StarterPackLandingScreen.tsx:317
 msgid "Download Bluesky"
@@ -2219,17 +2019,9 @@ msgstr "Descargar Bluesky"
 msgid "Download CAR file"
 msgstr "Descargar ficheiro CAR"
 
-#: src/components/dialogs/nuxs/TenMillion/index.tsx:622
-#~ msgid "Download image"
-#~ msgstr "Descargar imaxe"
-
 #: src/view/com/composer/text-input/TextInput.web.tsx:300
 msgid "Drop to add images"
-msgstr "Arrastrar para engadir imaxes"
-
-#: src/screens/Onboarding/StepModeration/AdultContentEnabledPref.tsx:120
-#~ msgid "Due to Apple policies, adult content can only be enabled on the web after completing sign up."
-#~ msgstr "Por mor das políticas de Apple, o contido para adultos só pode ser habilitado na web despois de completar o rexistro."
+msgstr "Arrastra para agregar imaxes"
 
 #: src/components/dialogs/MutedWords.tsx:153
 msgid "Duration:"
@@ -2237,58 +2029,47 @@ msgstr "Duración:"
 
 #: src/view/com/modals/ChangeHandle.tsx:245
 msgid "e.g. alice"
-msgstr "p. ex. alice"
+msgstr "ex. alicia"
 
 #: src/screens/Profile/Header/EditProfileDialog.tsx:321
 msgid "e.g. Alice Lastname"
-msgstr "p. ex. Alice Lastname"
-
-#: src/view/com/modals/EditProfile.tsx:180
-#~ msgid "e.g. Alice Roberts"
-#~ msgstr "p. ex. Alice Roberts"
+msgstr "ex. Apelido de Alicia"
 
 #: src/view/com/modals/ChangeHandle.tsx:367
 msgid "e.g. alice.com"
-msgstr "p. ex. alice.com"
-
-#: src/view/com/modals/EditProfile.tsx:198
-#~ msgid "e.g. Artist, dog-lover, and avid reader."
-#~ msgstr "p. ex. Artista, amante dos cans, e grande lector."
+msgstr "ex. alicia.com"
 
 #: src/lib/moderation/useGlobalLabelStrings.ts:43
 msgid "E.g. artistic nudes."
-msgstr "P. Ex. espidos artísticos."
+msgstr "ex. Espidos artísticos."
 
 #: src/view/com/modals/CreateOrEditList.tsx:263
 msgid "e.g. Great Posters"
-msgstr "p. ex. Os maiores publicadores"
+msgstr "ex. Grandes persoas"
 
 #: src/view/com/modals/CreateOrEditList.tsx:264
 msgid "e.g. Spammers"
-msgstr "p. ex. Spammers"
+msgstr "ex. Spam"
 
 #: src/view/com/modals/CreateOrEditList.tsx:292
 msgid "e.g. The posters who never miss."
-msgstr "p. ex. Os publicadores que sempre acertan."
+msgstr "ex. Persoas que sempre atinan."
 
 #: src/view/com/modals/CreateOrEditList.tsx:293
 msgid "e.g. Users that repeatedly reply with ads."
-msgstr "p. ex. Usuarios que responden de xeito constante con publicidade."
+msgstr "ex. Persoas que constantemente responden con publicidade."
 
 #: src/view/com/modals/InviteCodes.tsx:97
 msgid "Each code works once. You'll receive more invite codes periodically."
-msgstr "Cada código funciona unha vez. Recibirás máis códigos de convite de xeito regular."
+msgstr ""
+"Cada código funciona unha vez. Recibirás máis códigos de convite "
+"periodicamente."
 
 #: src/screens/StarterPack/StarterPackScreen.tsx:573
 #: src/screens/StarterPack/Wizard/index.tsx:560
 #: src/screens/StarterPack/Wizard/index.tsx:567
 #: src/view/screens/Feeds.tsx:386
 #: src/view/screens/Feeds.tsx:454
-msgid "Edit"
-msgstr "Editar"
-
-#: src/view/com/lists/ListMembers.tsx:146
-msgctxt "action"
 msgid "Edit"
 msgstr "Editar"
 
@@ -2310,72 +2091,55 @@ msgstr "Editar imaxe"
 #: src/view/com/util/forms/PostDropdownBtn.tsx:632
 #: src/view/com/util/forms/PostDropdownBtn.tsx:647
 msgid "Edit interaction settings"
-msgstr ""
+msgstr "Editar axustes de interacción"
 
 #: src/view/screens/ProfileList.tsx:518
 msgid "Edit list details"
-msgstr "Editar detalles da lista"
+msgstr "Editar os detalles da listaxe"
 
 #: src/view/com/modals/CreateOrEditList.tsx:230
 msgid "Edit Moderation List"
-msgstr "Editar lista de moderación"
+msgstr "Editar Listaxe de Moderación"
 
 #: src/Navigation.tsx:290
 #: src/view/screens/Feeds.tsx:384
 #: src/view/screens/Feeds.tsx:452
 #: src/view/screens/SavedFeeds.tsx:116
 msgid "Edit My Feeds"
-msgstr "Editar as miñas fontes"
-
-#: src/view/com/modals/EditProfile.tsx:147
-#~ msgid "Edit my profile"
-#~ msgstr "Editar o meu perfil"
+msgstr "Editar as Miñas Canles"
 
 #: src/components/StarterPack/Wizard/WizardEditListDialog.tsx:109
 msgid "Edit People"
-msgstr "Editar xente"
+msgstr "Editar Persoas"
 
 #: src/components/dialogs/PostInteractionSettingsDialog.tsx:66
 #: src/components/dialogs/PostInteractionSettingsDialog.tsx:204
 msgid "Edit post interaction settings"
-msgstr "Editar axustes de interacción coa publicación"
+msgstr "Editar axustes de interacción do chío"
 
 #: src/screens/Profile/Header/EditProfileDialog.tsx:269
 #: src/screens/Profile/Header/EditProfileDialog.tsx:275
 #: src/screens/Profile/Header/ProfileHeaderLabeler.tsx:176
 #: src/screens/Profile/Header/ProfileHeaderStandard.tsx:169
 msgid "Edit profile"
-msgstr "Editar perfil"
+msgstr "Editar o perfil"
 
 #: src/screens/Profile/Header/ProfileHeaderLabeler.tsx:179
 #: src/screens/Profile/Header/ProfileHeaderStandard.tsx:172
 msgid "Edit Profile"
-msgstr "Editar Perfil"
-
-#: src/view/com/home/HomeHeaderLayout.web.tsx:76
-#: src/view/screens/Feeds.tsx:416
-#~ msgid "Edit Saved Feeds"
-#~ msgstr "Editar as miñas fontes gardadas"
+msgstr "Editar o perfil"
 
 #: src/screens/StarterPack/StarterPackScreen.tsx:565
 msgid "Edit starter pack"
-msgstr "Edita paquete de inicio"
+msgstr "Editar paquete de inicio"
 
 #: src/view/com/modals/CreateOrEditList.tsx:225
 msgid "Edit User List"
-msgstr "Editar lista de usuarios"
+msgstr "Editar listaxe de Persoas"
 
 #: src/components/WhoCanReply.tsx:87
 msgid "Edit who can reply"
 msgstr "Editar quen pode responder"
-
-#: src/view/com/modals/EditProfile.tsx:188
-#~ msgid "Edit your display name"
-#~ msgstr "Edita o teu nome para amosar"
-
-#: src/view/com/modals/EditProfile.tsx:206
-#~ msgid "Edit your profile description"
-#~ msgstr "Edita a descrición do teu perfil"
 
 #: src/Navigation.tsx:372
 msgid "Edit your starter pack"
@@ -2386,87 +2150,78 @@ msgstr "Edita o teu paquete de inicio"
 msgid "Education"
 msgstr "Educación"
 
-#: src/components/dialogs/ThreadgateEditor.tsx:98
-#~ msgid "Either choose \"Everybody\" or \"Nobody\""
-#~ msgstr "Ou escolles a \"Todos\" ou a \"Ninguén\""
-
 #: src/screens/Signup/StepInfo/index.tsx:170
 #: src/view/com/modals/ChangeEmail.tsx:136
 msgid "Email"
-msgstr "Correo"
+msgstr "Enderezo electrónico"
 
 #: src/view/screens/Settings/DisableEmail2FADialog.tsx:64
 msgid "Email 2FA disabled"
-msgstr "2FA para correo deshabilitado"
+msgstr "Correo 2FA deshabilitado"
 
 #: src/screens/Login/ForgotPasswordForm.tsx:93
 msgid "Email address"
-msgstr "Enderezo de correo"
+msgstr "Enderezo de correo electrónico"
 
 #: src/components/intents/VerifyEmailIntentDialog.tsx:104
 msgid "Email Resent"
-msgstr "Volver enviar o correo"
+msgstr "Correo electrónico reenviado"
 
 #: src/view/com/modals/ChangeEmail.tsx:54
 #: src/view/com/modals/ChangeEmail.tsx:83
 msgid "Email updated"
-msgstr "Correo actualizado"
+msgstr "Correo electrónico actualizado"
 
 #: src/view/com/modals/ChangeEmail.tsx:106
 msgid "Email Updated"
-msgstr "Correo Actualizado"
+msgstr "Correo electrónico actualizado"
 
 #: src/view/com/modals/VerifyEmail.tsx:85
 msgid "Email verified"
-msgstr "Correo verificado"
+msgstr "Correo electrónico verificado"
 
 #: src/components/intents/VerifyEmailIntentDialog.tsx:79
 msgid "Email Verified"
-msgstr "Correo Verificado"
+msgstr "Correo electrónico verificado"
 
 #: src/view/screens/Settings/index.tsx:320
 msgid "Email:"
-msgstr "Correo:"
+msgstr "Enderezo electrónico:"
 
 #: src/components/dialogs/Embed.tsx:113
 msgid "Embed HTML code"
-msgstr "Código HTML incrustado"
+msgstr "Insertar código HTML"
 
 #: src/components/dialogs/Embed.tsx:97
 #: src/view/com/util/forms/PostDropdownBtn.tsx:469
 #: src/view/com/util/forms/PostDropdownBtn.tsx:471
 msgid "Embed post"
-msgstr "Publicación incrustada"
+msgstr "Insertar chío"
 
 #: src/components/dialogs/Embed.tsx:101
-msgid "Embed this post in your website. Simply copy the following snippet and paste it into the HTML code of your website."
-msgstr "Incrusta esta publicación no teu sitio web. Simplemente copia o seguinte snippet e pegao no código HTML do teu sitio web."
+msgid ""
+"Embed this post in your website. Simply copy the following snippet and "
+"paste it into the HTML code of your website."
+msgstr ""
+"Incrusta este chío no teu sitio web. Simplemente copia o seguinte fragmento "
+"e pégao no código HTML do teu sitio web."
 
 #: src/components/dialogs/EmbedConsent.tsx:100
 msgid "Enable {0} only"
-msgstr "Habilitar só {0}"
+msgstr "Activar {0} unicamente"
 
 #: src/screens/Moderation/index.tsx:343
 msgid "Enable adult content"
-msgstr "Habilitar o contido para adultos"
-
-#: src/screens/Onboarding/StepModeration/AdultContentEnabledPref.tsx:94
-#~ msgid "Enable Adult Content"
-#~ msgstr "Habilitar contido para adultos"
-
-#: src/screens/Onboarding/StepModeration/AdultContentEnabledPref.tsx:78
-#: src/screens/Onboarding/StepModeration/AdultContentEnabledPref.tsx:79
-#~ msgid "Enable adult content in your feeds"
-#~ msgstr "Habilitar contido para adultos nas túas fontes"
+msgstr "Activar contido para persoas adultas"
 
 #: src/components/dialogs/EmbedConsent.tsx:81
 #: src/components/dialogs/EmbedConsent.tsx:88
 msgid "Enable external media"
-msgstr "Habilitar medios externos"
+msgstr "Activar medios externos"
 
 #: src/view/screens/PreferencesExternalEmbeds.tsx:71
 msgid "Enable media players for"
-msgstr "Habilitar reprodutores de medios para"
+msgstr "Reproducir multimedia de"
 
 #: src/view/screens/NotificationsSettings.tsx:68
 #: src/view/screens/NotificationsSettings.tsx:71
@@ -2475,11 +2230,7 @@ msgstr "Habilitar notificacións prioritarias"
 
 #: src/view/com/util/post-embeds/VideoEmbedInner/web-controls/VideoControls.tsx:389
 msgid "Enable subtitles"
-msgstr "Habilitar subtítulos"
-
-#: src/view/screens/PreferencesFollowingFeed.tsx:145
-#~ msgid "Enable this setting to only see replies between people you follow."
-#~ msgstr "Habilita este axuste para ver só as respostas entre a xente que segues."
+msgstr "Activar lexendas"
 
 #: src/components/dialogs/EmbedConsent.tsx:93
 msgid "Enable this source only"
@@ -2489,77 +2240,74 @@ msgstr "Habilitar só esta fonte"
 #: src/screens/Messages/Settings.tsx:127
 #: src/screens/Moderation/index.tsx:354
 msgid "Enabled"
-msgstr "Habilitado"
+msgstr "Activado"
 
 #: src/screens/Profile/Sections/Feed.tsx:114
 msgid "End of feed"
-msgstr "Fin da fonte"
-
-#: src/components/Lists.tsx:52
-#~ msgid "End of list"
-#~ msgstr "Fin da lista"
-
-#: src/tours/Tooltip.tsx:159
-#~ msgid "End of onboarding tour window. Do not move forward. Instead, go backward for more options, or press to skip."
-#~ msgstr "Fin do percorrido pola benvida. Non avances, vai cara atrás para máis opcións, ou preme en omitir."
+msgstr "Fin das canles"
 
 #: src/view/com/composer/videos/SubtitleDialog.tsx:159
 msgid "Ensure you have selected a language for each subtitle file."
-msgstr "Verifica que seleccionaches unha lingua por cada ficheiro de subtítulos."
+msgstr "Asegúrate de ter seleccionado un idioma para cada ficheiro das lexendas."
 
 #: src/view/com/modals/AddAppPasswords.tsx:161
 msgid "Enter a name for this App Password"
-msgstr "Inserir un nome para este contrasinal"
+msgstr "Ingresa un nome para este contrasinal de aplicación"
 
 #: src/screens/Login/SetNewPasswordForm.tsx:133
 msgid "Enter a password"
-msgstr "Inserir un contrasinal"
+msgstr "Ingresa un contrasinal"
 
 #: src/components/dialogs/MutedWords.tsx:127
 #: src/components/dialogs/MutedWords.tsx:128
 msgid "Enter a word or tag"
-msgstr "Inserir palabra ou etiqueta"
+msgstr "Ingresa unha palabra ou etiqueta"
 
 #: src/components/dialogs/VerifyEmailDialog.tsx:75
 msgid "Enter Code"
-msgstr "Inserir código"
+msgstr "Ingresa Código"
 
 #: src/view/com/modals/VerifyEmail.tsx:113
 msgid "Enter Confirmation Code"
-msgstr "Inserir código de confirmación"
+msgstr "Ingresa Código de Confirmación"
 
 #: src/view/com/modals/ChangePassword.tsx:154
 msgid "Enter the code you received to change your password."
-msgstr "Insire o código que recibiches para mudar o contrasinal."
+msgstr "Ingresa o código que recibiches para cambiar o teu contrasinal."
 
 #: src/view/com/modals/ChangeHandle.tsx:357
 msgid "Enter the domain you want to use"
-msgstr "Insire o dominio que dexesas usar"
+msgstr "Introduce o dominio que queres empregar"
 
 #: src/screens/Login/ForgotPasswordForm.tsx:113
-msgid "Enter the email you used to create your account. We'll send you a \"reset code\" so you can set a new password."
-msgstr "Insire o correo que utilizaches para crear a túa conta. Enviáremosche un \"código de restablecemento\" para que poidas definir un novo contrasinal."
+msgid ""
+"Enter the email you used to create your account. We'll send you a \"reset "
+"code\" so you can set a new password."
+msgstr ""
+"Introduce o correo electrónico que utilizaches para crear a túa conta. "
+"Enviarémosche un \"código de restablecemento\" para que poidas establecer "
+"un novo contrasinal."
 
 #: src/components/dialogs/BirthDateSettings.tsx:107
 msgid "Enter your birth date"
-msgstr "Insire a data de nacemento"
+msgstr "Ingresa a túa data de nacemento"
 
 #: src/screens/Login/ForgotPasswordForm.tsx:99
 #: src/screens/Signup/StepInfo/index.tsx:182
 msgid "Enter your email address"
-msgstr "Insire o teu enderezo de correo"
+msgstr "Introduce o enderezo de correo electrónico"
 
 #: src/view/com/modals/ChangeEmail.tsx:42
 msgid "Enter your new email above"
-msgstr "Insire arriba o teu novo correo"
+msgstr "Ingresa o teu novo correo arriba"
 
 #: src/view/com/modals/ChangeEmail.tsx:112
 msgid "Enter your new email address below."
-msgstr "Insire abaixo o teu novo enderezo de correo."
+msgstr "Introduce o teu novo enderezo de correo electrónico a continuación."
 
 #: src/screens/Login/index.tsx:98
 msgid "Enter your username and password"
-msgstr "Insire o teu nome de usuario e contrasinal"
+msgstr "Introduce o teu alcume e contrasinal"
 
 #: src/view/com/composer/Composer.tsx:1350
 msgid "Error"
@@ -2567,16 +2315,16 @@ msgstr "Erro"
 
 #: src/view/screens/Settings/ExportCarDialog.tsx:46
 msgid "Error occurred while saving file"
-msgstr "Produciuse un erro ao gardar o ficheiro"
+msgstr "Ocorreu un erro ao gardar o ficheiro"
 
 #: src/screens/Signup/StepCaptcha/index.tsx:56
 msgid "Error receiving captcha response."
-msgstr ""
+msgstr "Error ao recibir a resposta do captcha."
 
 #: src/screens/Onboarding/StepInterests/index.tsx:183
 #: src/view/screens/Search/Search.tsx:122
 msgid "Error:"
-msgstr "Erro:"
+msgstr "Error:"
 
 #: src/components/dialogs/PostInteractionSettingsDialog.tsx:365
 msgid "Everybody"
@@ -2584,11 +2332,11 @@ msgstr "Todos"
 
 #: src/components/WhoCanReply.tsx:67
 msgid "Everybody can reply"
-msgstr "Calquera pode responder"
+msgstr "Todo o mundo pode responder"
 
 #: src/components/WhoCanReply.tsx:213
 msgid "Everybody can reply to this post."
-msgstr "Calquera pode responder a esta publicación."
+msgstr "Todo o mundo pode responder a este chío."
 
 #: src/screens/Messages/Settings.tsx:77
 #: src/screens/Messages/Settings.tsx:80
@@ -2601,15 +2349,15 @@ msgstr "Mencións ou respostas excesivas"
 
 #: src/lib/moderation/useReportOptions.ts:86
 msgid "Excessive or unwanted messages"
-msgstr "Mensaxes excesivas ou non desexadas"
+msgstr "Mensaxes excesivos ou non desexados"
 
 #: src/components/dialogs/MutedWords.tsx:311
 msgid "Exclude users you follow"
-msgstr "Excluír os usuarios que sigues"
+msgstr "Excluír á contas que segues"
 
 #: src/components/dialogs/MutedWords.tsx:514
 msgid "Excludes users you follow"
-msgstr "Exclúe os usuarios que sigues"
+msgstr "Exclúe ás contas que segues"
 
 #: src/view/com/util/post-embeds/VideoEmbedInner/web-controls/VideoControls.tsx:406
 msgid "Exit fullscreen"
@@ -2617,60 +2365,66 @@ msgstr "Saír da pantalla completa"
 
 #: src/view/com/modals/DeleteAccount.tsx:293
 msgid "Exits account deletion process"
-msgstr ""
+msgstr "Saír do proceso de eliminación de conta"
 
 #: src/view/com/modals/ChangeHandle.tsx:138
 msgid "Exits handle change process"
-msgstr "Saír do proceso de cambio do nome de usuario"
+msgstr "Saír do proceso de cambio de alcume"
 
 #: src/view/com/modals/CropImage.web.tsx:95
 msgid "Exits image cropping process"
-msgstr ""
+msgstr "Saír do proceso de recorte de imaxe"
 
 #: src/view/com/lightbox/Lightbox.web.tsx:130
 msgid "Exits image view"
-msgstr ""
+msgstr "Saír da vista de imaxe"
 
 #: src/view/com/modals/ListAddRemoveUsers.tsx:89
 msgid "Exits inputting search query"
-msgstr ""
+msgstr "Saír da entrada da consulta de búsqueda"
 
 #: src/view/com/lightbox/Lightbox.web.tsx:183
 msgid "Expand alt text"
-msgstr ""
+msgstr "Expandir o texto alt"
 
 #: src/view/com/notifications/FeedItem.tsx:266
 msgid "Expand list of users"
-msgstr ""
+msgstr "Expandir listaxe de persoas"
 
 #: src/view/com/composer/ComposerReplyTo.tsx:70
 #: src/view/com/composer/ComposerReplyTo.tsx:73
 msgid "Expand or collapse the full post you are replying to"
-msgstr ""
+msgstr "Expandir ou minimizar o chío completo ao que estás respondendo"
 
 #: src/lib/api/index.ts:376
 msgid "Expected uri to resolve to a record"
-msgstr "Uri agardada para resolver un rexistro"
+msgstr "Esperábase que a URI se resolvera nun rexistro"
 
 #: src/view/screens/NotificationsSettings.tsx:78
-msgid "Experimental: When this preference is enabled, you'll only receive reply and quote notifications from users you follow. We'll continue to add more controls here over time."
+msgid ""
+"Experimental: When this preference is enabled, you'll only receive reply "
+"and quote notifications from users you follow. We'll continue to add more "
+"controls here over time."
 msgstr ""
+"Experimental: Cuando esta preferencia estea habilitada, só recibirás "
+"notificacións de respostas e citas de contas que segues. Seguiremos "
+"engadindo máis controis aquí co tempo."
 
 #: src/components/dialogs/MutedWords.tsx:500
 msgid "Expired"
-msgstr "Caducada"
+msgstr "Expirado"
 
 #: src/components/dialogs/MutedWords.tsx:502
 msgid "Expires {0}"
-msgstr "Caducada o {0}"
+msgstr "Expira {0}"
 
 #: src/lib/moderation/useGlobalLabelStrings.ts:47
 msgid "Explicit or potentially disturbing media."
-msgstr "Medios explícitos ou inapropiados."
+msgstr "Medios explícitos ou potencialmente perturbadores."
 
 #: src/lib/moderation/useGlobalLabelStrings.ts:35
 msgid "Explicit sexual images."
-msgstr "Imaxes de contido sexual explícito."
+msgstr "Imaxes sexuais explícitas."
 
 #: src/view/screens/Settings/index.tsx:753
 msgid "Export my data"
@@ -2679,7 +2433,7 @@ msgstr "Exportar os meus datos"
 #: src/view/screens/Settings/ExportCarDialog.tsx:61
 #: src/view/screens/Settings/index.tsx:764
 msgid "Export My Data"
-msgstr "Exportar os meus Datos"
+msgstr "Exportar Os Meus Datos"
 
 #: src/components/dialogs/EmbedConsent.tsx:54
 #: src/components/dialogs/EmbedConsent.tsx:58
@@ -2688,136 +2442,134 @@ msgstr "Medios externos"
 
 #: src/components/dialogs/EmbedConsent.tsx:70
 #: src/view/screens/PreferencesExternalEmbeds.tsx:62
-msgid "External media may allow websites to collect information about you and your device. No information is sent or requested until you press the \"play\" button."
-msgstr "É posíbel que os medios externos permitan obter información a outros sitios web sobre ti e o teu dispositivo. Non se enviará información até que premas o botón \"reproducir\"."
+msgid ""
+"External media may allow websites to collect information about you and your "
+"device. No information is sent or requested until you press the \"play\" "
+"button."
+msgstr ""
+"É posíbel que medios externos permitan que outros sitios recopilen datos "
+"sobre ti e o teu dispositivo. Non se envía ou solicita ningún tipo de "
+"información ata que presiones o botón de \"play\"."
 
 #: src/Navigation.tsx:309
 #: src/view/screens/PreferencesExternalEmbeds.tsx:51
 #: src/view/screens/Settings/index.tsx:646
 msgid "External Media Preferences"
-msgstr "Preferencias de medios externos"
+msgstr "Medios externos"
 
 #: src/view/screens/Settings/index.tsx:637
 msgid "External media settings"
-msgstr "Axustes de medios externos"
+msgstr "Medios externos"
 
 #: src/view/com/modals/AddAppPasswords.tsx:119
 #: src/view/com/modals/AddAppPasswords.tsx:123
 msgid "Failed to create app password."
-msgstr "Produciuse un erro ao crear o contrasinal."
+msgstr "Error ao crear o contrasinal da aplicación."
 
 #: src/screens/StarterPack/Wizard/index.tsx:238
 #: src/screens/StarterPack/Wizard/index.tsx:246
 msgid "Failed to create starter pack"
-msgstr "Produciuse un erro ao crear o paquete de inicio"
+msgstr "Error ao crear o paquete de inicio."
 
 #: src/view/com/modals/CreateOrEditList.tsx:186
 msgid "Failed to create the list. Check your internet connection and try again."
-msgstr "Produciuse un erro ao crear a lista. Comproba a túa conexión a internet e téntao de novo."
+msgstr ""
+"Error ao crear a listaxe. Verifica a túa conexión a Internet e volve a "
+"probar."
 
 #: src/components/dms/MessageMenu.tsx:73
 msgid "Failed to delete message"
-msgstr "Produciuse un erro ao eliminar esta mensaxe"
+msgstr "Error ao eliminar a mensaxe."
 
 #: src/view/com/util/forms/PostDropdownBtn.tsx:200
 msgid "Failed to delete post, please try again"
-msgstr "Produciuse un erro ao eliminar esta publicación, por favor téntao de novo"
+msgstr "Error ao eliminar o chío, por favor, inténtao de novo."
 
 #: src/screens/StarterPack/StarterPackScreen.tsx:697
 msgid "Failed to delete starter pack"
-msgstr "Produciuse un erro ao eliminar o paquete de inicio"
+msgstr "Error ao eliminar o paquete inicial."
 
 #: src/view/screens/Search/Explore.tsx:427
 #: src/view/screens/Search/Explore.tsx:455
 msgid "Failed to load feeds preferences"
-msgstr "Produciuse un erro ao cargar as preferencias de fontes"
+msgstr "Error ao cargar as preferencias das canles."
 
 #: src/components/dialogs/GifSelect.tsx:224
 msgid "Failed to load GIFs"
-msgstr "Produciuse un erro ao cargar os GIFs"
+msgstr "Error ao cargar os GIFs."
 
 #: src/screens/Messages/components/MessageListError.tsx:23
 msgid "Failed to load past messages"
-msgstr "Produciuse un erro ao cargar mensaxes antigas"
-
-#: src/screens/Messages/Conversation/MessageListError.tsx:28
-#~ msgid "Failed to load past messages."
-#~ msgstr "Produciuse un erro ao cargar mensaxes antigas"
+msgstr "Error ao cargar as mensaxes anteriores."
 
 #: src/view/screens/Search/Explore.tsx:420
 #: src/view/screens/Search/Explore.tsx:448
 msgid "Failed to load suggested feeds"
-msgstr "Produciuse un erro ao cargar as fontes suxeridas"
+msgstr "Error ao cargar as canles suxeridas."
 
 #: src/view/screens/Search/Explore.tsx:378
 msgid "Failed to load suggested follows"
-msgstr "Produciuse un erro ao cargar os seguidos suxeridos"
+msgstr "Error ao cargar as suxerencias de seguimento."
 
 #: src/state/queries/pinned-post.ts:75
 msgid "Failed to pin post"
-msgstr ""
+msgstr "Error ao fixar o chío."
 
 #: src/view/com/lightbox/Lightbox.tsx:97
 msgid "Failed to save image: {0}"
-msgstr "Produciuse un erro ao gardar a imaxe: {0}"
+msgstr "Error ao gardar a imaxe: {0}"
 
 #: src/state/queries/notifications/settings.ts:39
 msgid "Failed to save notification preferences, please try again"
-msgstr "Produciuse un erro ao gardar as preferencias de notificacións, por favor téntao de novo"
+msgstr ""
+"Error ao gardar as preferencias de notificación, por favor, inténtao de "
+"novo."
 
 #: src/components/dms/MessageItem.tsx:233
 msgid "Failed to send"
-msgstr "Produciuse un erro no envío"
-
-#: src/screens/Messages/Conversation/MessageListError.tsx:29
-#~ msgid "Failed to send message(s)."
-#~ msgstr "Produciuse un erro ao enviar a mensaxe(s)."
+msgstr "Error ao enviar"
 
 #: src/components/moderation/LabelsOnMeDialog.tsx:229
 #: src/screens/Messages/components/ChatDisabled.tsx:87
 msgid "Failed to submit appeal, please try again."
-msgstr "Produciuse un erro ao enviar a apelación, por favor téntao de novo."
+msgstr "Error ao enviar a apelación, por favor, inténtao de novo."
 
 #: src/view/com/util/forms/PostDropdownBtn.tsx:229
 msgid "Failed to toggle thread mute, please try again"
-msgstr "Produciuse un erro ao mudar o estado silenciado do fío, téntao de novo."
+msgstr "Error ao cambiar o estado de silencio do fío, por favor, inténtao de novo."
 
 #: src/components/FeedCard.tsx:276
 msgid "Failed to update feeds"
-msgstr "Produciuse un erro ao actualizar as fontes"
+msgstr "Error ao actualizar as canles"
 
 #: src/screens/Messages/Settings.tsx:36
 msgid "Failed to update settings"
-msgstr "Produciuse un erro ao actualizar os axustes"
+msgstr "Error ao actualizar os axustes"
 
 #: src/lib/media/video/upload.ts:72
 #: src/lib/media/video/upload.web.ts:74
 #: src/lib/media/video/upload.web.ts:78
 #: src/lib/media/video/upload.web.ts:88
 msgid "Failed to upload video"
-msgstr "Produciuse un erro ao subir o vídeo"
+msgstr "Error ao subir video"
 
 #: src/Navigation.tsx:225
 msgid "Feed"
-msgstr "Fonte"
+msgstr "Canles"
 
 #: src/components/FeedCard.tsx:134
 #: src/view/com/feeds/FeedSourceCard.tsx:250
 msgid "Feed by {0}"
-msgstr "Fonte por {0}"
-
-#: src/view/screens/Feeds.tsx:709
-#~ msgid "Feed offline"
-#~ msgstr "Novas fora de liña"
+msgstr "Canle por {0}"
 
 #: src/components/StarterPack/Wizard/WizardListCard.tsx:55
 msgid "Feed toggle"
-msgstr ""
+msgstr "Alternar canle"
 
 #: src/view/shell/desktop/RightNav.tsx:70
 #: src/view/shell/Drawer.tsx:348
 msgid "Feedback"
-msgstr "Comentario"
+msgstr "Comentarios"
 
 #: src/view/com/util/forms/PostDropdownBtn.tsx:271
 #: src/view/com/util/forms/PostDropdownBtn.tsx:280
@@ -2833,66 +2585,58 @@ msgstr "Comentario enviado!"
 #: src/view/shell/desktop/LeftNav.tsx:401
 #: src/view/shell/Drawer.tsx:505
 msgid "Feeds"
-msgstr "Fontes"
+msgstr "Canles"
 
 #: src/view/screens/SavedFeeds.tsx:205
-msgid "Feeds are custom algorithms that users build with a little coding expertise. <0/> for more information."
-msgstr "As fontes son algoritmos personalizados creados por usuarios con nocións de programación. <0/> para máis información."
-
-#: src/screens/Onboarding/StepTopicalFeeds.tsx:80
-#~ msgid "Feeds can be topical as well!"
-#~ msgstr "As fontes tamén poden ser de actualidade!"
+msgid ""
+"Feeds are custom algorithms that users build with a little coding "
+"expertise. <0/> for more information."
+msgstr ""
+"As canles son algoritmos personalizados que as persoas constrúen cun poco "
+"de experiencia en codificación. <0/> para máis información."
 
 #: src/components/FeedCard.tsx:273
 #: src/view/screens/SavedFeeds.tsx:83
 msgid "Feeds updated!"
-msgstr "Fontes actualizadas!"
+msgstr "Canles actualizadas!"
 
 #: src/view/com/modals/ChangeHandle.tsx:468
 msgid "File Contents"
-msgstr "Contido do ficheiro"
+msgstr "Contido do Ficheiro"
 
 #: src/view/screens/Settings/ExportCarDialog.tsx:42
 msgid "File saved successfully!"
-msgstr "Ficheiro gardado con éxito!"
+msgstr "Ficheiro gardado exitosamente!"
 
 #: src/lib/moderation/useLabelBehaviorDescription.ts:66
 msgid "Filter from feeds"
-msgstr "Filtrar nas fontes"
+msgstr "Filtro de canles"
 
 #: src/screens/Onboarding/StepFinished.tsx:287
 msgid "Finalizing"
-msgstr "Rematando"
+msgstr "Finalizando"
 
 #: src/view/com/posts/CustomFeedEmptyState.tsx:47
 #: src/view/com/posts/FollowingEmptyState.tsx:53
 #: src/view/com/posts/FollowingEndOfFeed.tsx:54
 msgid "Find accounts to follow"
-msgstr "Procurar contas a seguir"
-
-#: src/tours/HomeTour.tsx:88
-#~ msgid "Find more feeds and accounts to follow in the Explore page."
-#~ msgstr "Atopa máis fontes e contas para seguir na páxina de exploración."
+msgstr "Buscar contas para seguir"
 
 #: src/view/screens/Search/Search.tsx:612
 msgid "Find posts and users on Bluesky"
-msgstr "Procurar publicacións e usuarios no Bluesky"
+msgstr "Buscar chíos e contas en Bluesky"
 
 #: src/view/screens/PreferencesFollowingFeed.tsx:52
 msgid "Fine-tune the content you see on your Following feed."
-msgstr ""
+msgstr "Axusta o contido que ves nas túas canles de Seguimento."
 
 #: src/view/screens/PreferencesThreads.tsx:55
 msgid "Fine-tune the discussion threads."
-msgstr ""
+msgstr "Axusta os fíos de discusión."
 
 #: src/screens/StarterPack/Wizard/index.tsx:200
 msgid "Finish"
 msgstr "Rematar"
-
-#: src/tours/Tooltip.tsx:149
-#~ msgid "Finish tour and begin using the application"
-#~ msgstr "Rematar o percorrido e comezar a usar a aplicación"
 
 #: src/screens/Onboarding/index.tsx:35
 msgid "Fitness"
@@ -2900,83 +2644,50 @@ msgstr "Fitness"
 
 #: src/screens/Onboarding/StepFinished.tsx:267
 msgid "Flexible"
-msgstr ""
+msgstr "Flexíbel"
 
-#: src/view/com/modals/EditImage.tsx:116
-#~ msgid "Flip horizontal"
-#~ msgstr "Voltear horizontalmente"
-
-#: src/view/com/modals/EditImage.tsx:121
-#: src/view/com/modals/EditImage.tsx:288
-#~ msgid "Flip vertically"
-#~ msgstr "Voltear verticalmente"
-
-#. User is not following this account, click to follow
 #: src/components/ProfileCard.tsx:358
 #: src/components/ProfileHoverCard/index.web.tsx:449
 #: src/components/ProfileHoverCard/index.web.tsx:460
 #: src/screens/Profile/Header/ProfileHeaderStandard.tsx:224
 #: src/view/com/post-thread/PostThreadFollowBtn.tsx:132
-msgid "Follow"
-msgstr "Seguir"
-
-#: src/view/com/profile/FollowButton.tsx:70
-msgctxt "action"
+#. User is not following this account, click to follow
 msgid "Follow"
 msgstr "Seguir"
 
 #: src/screens/Profile/Header/ProfileHeaderStandard.tsx:208
 #: src/view/com/post-thread/PostThreadFollowBtn.tsx:114
 msgid "Follow {0}"
-msgstr "Segue a {0}"
+msgstr "Seguir {0}"
 
 #: src/view/com/posts/AviFollowButton.tsx:68
 msgid "Follow {name}"
-msgstr "Seguir a {name}"
+msgstr "Seguir {name}"
 
 #: src/components/ProgressGuide/List.tsx:54
 msgid "Follow 7 accounts"
-msgstr ""
+msgstr "Sigue 7 contas"
 
 #: src/view/com/profile/ProfileMenu.tsx:222
 #: src/view/com/profile/ProfileMenu.tsx:233
 msgid "Follow Account"
-msgstr "Seguir Conta"
+msgstr "Seguir conta"
 
 #: src/screens/StarterPack/StarterPackScreen.tsx:427
 #: src/screens/StarterPack/StarterPackScreen.tsx:434
 msgid "Follow all"
-msgstr "Seguir todo"
-
-#: src/screens/Onboarding/StepSuggestedAccounts/index.tsx:187
-#~ msgid "Follow All"
-#~ msgstr "Seguir a todos"
+msgstr "Seguir a todos"
 
 #: src/screens/Profile/Header/ProfileHeaderStandard.tsx:222
 #: src/view/com/post-thread/PostThreadFollowBtn.tsx:130
 msgid "Follow Back"
-msgstr ""
-
-#: src/view/com/profile/FollowButton.tsx:79
-msgctxt "action"
-msgid "Follow Back"
-msgstr ""
+msgstr "Seguir de volta"
 
 #: src/view/screens/Search/Explore.tsx:334
-msgid "Follow more accounts to get connected to your interests and build your network."
-msgstr "Segue máis contas para conectar aos seus intereses e crear a túa rede."
-
-#: src/screens/Onboarding/StepSuggestedAccounts/index.tsx:182
-#~ msgid "Follow selected accounts and continue to the next step"
-#~ msgstr ""
-
-#: src/components/KnownFollowers.tsx:169
-#~ msgid "Followed by"
-#~ msgstr "Seguido por"
-
-#: src/view/com/profile/ProfileCard.tsx:190
-#~ msgid "Followed by {0}"
-#~ msgstr "Seguido por {0}"
+msgid ""
+"Follow more accounts to get connected to your interests and build your "
+"network."
+msgstr "Sigue máis contas para conectarte cos teus intereses e ampliar a túa rede."
 
 #: src/components/KnownFollowers.tsx:231
 msgid "Followed by <0>{0}</0>"
@@ -2991,24 +2702,24 @@ msgid "Followed by <0>{0}</0> and <1>{1}</1>"
 msgstr "Seguido por <0>{0}</0> e <1>{1}</1>"
 
 #: src/components/KnownFollowers.tsx:186
-msgid "Followed by <0>{0}</0>, <1>{1}</1>, and {2, plural, one {# other} other {# others}}"
-msgstr "Seguido por <0>{0}</0>, <1>{1}</1>, e {2, plural, one {# other} other {# others}}"
+msgid ""
+"Followed by <0>{0}</0>, <1>{1}</1>, and {2, plural, one {# other} other {# "
+"others}}"
+msgstr ""
+"Seguido por <0>{0}</0>, <1>{1}</1>, e {2, plural, one {# other} other {# "
+"others}}"
 
 #: src/components/dialogs/PostInteractionSettingsDialog.tsx:404
 msgid "Followed users"
-msgstr "Usuarios seguidos"
-
-#: src/view/screens/PreferencesFollowingFeed.tsx:152
-#~ msgid "Followed users only"
-#~ msgstr "Só usuarios seguidos"
+msgstr "Persoas seguidas"
 
 #: src/view/com/notifications/FeedItem.tsx:207
 msgid "followed you"
-msgstr "seguidos por ti"
+msgstr "comezou a seguirte"
 
 #: src/view/com/notifications/FeedItem.tsx:205
 msgid "followed you back"
-msgstr ""
+msgstr "séguete"
 
 #: src/view/screens/ProfileFollowers.tsx:30
 #: src/view/screens/ProfileFollowers.tsx:31
@@ -3024,7 +2735,6 @@ msgstr "Seguidores de @{0} que coñeces"
 msgid "Followers you know"
 msgstr "Seguidores que coñeces"
 
-#. User is following this account, click to unfollow
 #: src/components/ProfileCard.tsx:352
 #: src/components/ProfileHoverCard/index.web.tsx:448
 #: src/components/ProfileHoverCard/index.web.tsx:459
@@ -3034,6 +2744,7 @@ msgstr "Seguidores que coñeces"
 #: src/view/screens/ProfileFollows.tsx:30
 #: src/view/screens/ProfileFollows.tsx:31
 #: src/view/screens/SavedFeeds.tsx:431
+#. User is following this account, click to unfollow
 msgid "Following"
 msgstr "Seguindo"
 
@@ -3044,21 +2755,17 @@ msgstr "Seguindo {0}"
 
 #: src/view/com/posts/AviFollowButton.tsx:50
 msgid "Following {name}"
-msgstr "Seguindo a {name}"
+msgstr "Seguindo {name}"
 
 #: src/view/screens/Settings/index.tsx:540
 msgid "Following feed preferences"
-msgstr "Preferencias da fonte de seguimento"
+msgstr "Preferencias das canles de Seguimento"
 
 #: src/Navigation.tsx:296
 #: src/view/screens/PreferencesFollowingFeed.tsx:49
 #: src/view/screens/Settings/index.tsx:549
 msgid "Following Feed Preferences"
-msgstr "Preferencias da fonte de seguimento"
-
-#: src/tours/HomeTour.tsx:59
-#~ msgid "Following shows the latest posts from people you follow."
-#~ msgstr "Amosa as últimas publicacións da xente que segues."
+msgstr "Preferencias das canles de Seguimento"
 
 #: src/screens/Profile/Header/Handle.tsx:33
 msgid "Follows you"
@@ -3084,51 +2791,54 @@ msgid "Food"
 msgstr "Comida"
 
 #: src/view/com/modals/DeleteAccount.tsx:129
-msgid "For security reasons, we'll need to send a confirmation code to your email address."
-msgstr "Por motivos de seguranza, enviaremos un código de confirmación ao teu enderezo de correo."
+msgid ""
+"For security reasons, we'll need to send a confirmation code to your email "
+"address."
+msgstr ""
+"Por razóns de seguridade, teremos que enviarche un código de confirmación "
+"ao teu enderezo de correo electrónico."
 
 #: src/view/com/modals/AddAppPasswords.tsx:233
-msgid "For security reasons, you won't be able to view this again. If you lose this password, you'll need to generate a new one."
+msgid ""
+"For security reasons, you won't be able to view this again. If you lose "
+"this password, you'll need to generate a new one."
 msgstr ""
+"Por razóns de seguridade, non poderás volver a velo de novo. Se perdes este "
+"contrasinal, terás que xerar un novo."
 
 #: src/components/dialogs/nuxs/NeueTypography.tsx:73
 #: src/screens/Settings/AppearanceSettings.tsx:143
 msgid "For the best experience, we recommend using the theme font."
-msgstr ""
+msgstr "Para unha mellor experiencia, recomendamos que uses a fonte do tema."
 
 #: src/components/dialogs/MutedWords.tsx:178
 msgid "Forever"
-msgstr ""
+msgstr "Para sempte"
 
 #: src/screens/Login/index.tsx:126
 #: src/screens/Login/index.tsx:141
 msgid "Forgot Password"
-msgstr ""
+msgstr "Esquecín o meu contrasinal"
 
 #: src/screens/Login/LoginForm.tsx:230
 msgid "Forgot password?"
-msgstr ""
+msgstr "Esquecéches o teu contrasinal?"
 
 #: src/screens/Login/LoginForm.tsx:241
 msgid "Forgot?"
-msgstr ""
+msgstr "Esquecéchelo?"
 
 #: src/lib/moderation/useReportOptions.ts:54
 msgid "Frequently Posts Unwanted Content"
-msgstr ""
+msgstr "Publicacións frecuentes de contido non desexado"
 
 #: src/screens/Hashtag.tsx:117
 msgid "From @{sanitizedAuthor}"
 msgstr "De @{sanitizedAuthor}"
 
-#: src/view/com/posts/FeedItem.tsx:273
-msgctxt "from-feed"
-msgid "From <0/>"
-msgstr "De <0/>"
-
 #: src/view/com/util/post-embeds/VideoEmbedInner/web-controls/VideoControls.tsx:407
 msgid "Fullscreen"
-msgstr "Pantalla completa"
+msgstr "Pantalla Completa"
 
 #: src/view/com/composer/photos/SelectPhotoBtn.tsx:50
 msgid "Gallery"
@@ -3136,15 +2846,11 @@ msgstr "Galería"
 
 #: src/components/StarterPack/ProfileStarterPacks.tsx:280
 msgid "Generate a starter pack"
-msgstr "Xerar un paquete de inicio"
+msgstr "Xera un paquete de inicio"
 
 #: src/view/shell/Drawer.tsx:352
 msgid "Get help"
-msgstr "Obter axuda"
-
-#: src/components/dms/MessagesNUX.tsx:168
-#~ msgid "Get started"
-#~ msgstr "Comezar"
+msgstr "Obtén axuda"
 
 #: src/view/com/modals/VerifyEmail.tsx:197
 #: src/view/com/modals/VerifyEmail.tsx:199
@@ -3161,11 +2867,11 @@ msgstr "GIF"
 
 #: src/screens/Onboarding/StepProfile/index.tsx:234
 msgid "Give your profile a face"
-msgstr "Dálle unha faciana ao teu perfil"
+msgstr "Dálle ao teu perfil unha cara bonita"
 
 #: src/lib/moderation/useReportOptions.ts:39
 msgid "Glaring violations of law or terms of service"
-msgstr "Violacións manifestas da lei ou dos termos do servizo"
+msgstr "Violacións flagrantes da Lei ou dos Termos de servizo"
 
 #: src/components/moderation/ScreenHider.tsx:154
 #: src/components/moderation/ScreenHider.tsx:163
@@ -3188,10 +2894,6 @@ msgstr "Volver"
 msgid "Go Back"
 msgstr "Volver"
 
-#: src/screens/StarterPack/StarterPackLandingScreen.tsx:189
-#~ msgid "Go back to previous screen"
-#~ msgstr "Volver á pantalla anterior"
-
 #: src/components/dms/ReportDialog.tsx:149
 #: src/components/ReportDialog/SelectReportOptionView.tsx:80
 #: src/components/ReportDialog/SubmitView.tsx:109
@@ -3211,7 +2913,7 @@ msgstr "Ir ao inicio"
 
 #: src/view/screens/NotFound.tsx:56
 msgid "Go Home"
-msgstr "Ir ao Inicio"
+msgstr "Ir ao inicio"
 
 #: src/screens/Messages/components/ChatListItem.tsx:264
 msgid "Go to conversation with {0}"
@@ -3226,35 +2928,31 @@ msgstr "Ir ao seguinte"
 msgid "Go to profile"
 msgstr "Ir ao perfil"
 
-#: src/tours/Tooltip.tsx:138
-#~ msgid "Go to the next step of the tour"
-#~ msgstr "Volver ao paso anterior do percorrido"
-
 #: src/components/dms/ConvoMenu.tsx:164
 msgid "Go to user's profile"
-msgstr "Ir ao perfil do usuario"
+msgstr "Ir ao perfil da conta"
 
 #: src/lib/moderation/useGlobalLabelStrings.ts:46
 #: src/view/com/composer/labels/LabelsBtn.tsx:199
 #: src/view/com/composer/labels/LabelsBtn.tsx:202
 msgid "Graphic Media"
-msgstr "Medios gráficos"
+msgstr "Contido Gráfico"
 
 #: src/state/shell/progress-guide.tsx:161
 msgid "Half way there!"
-msgstr ""
+msgstr "Xa está na metade do camiño!"
 
 #: src/view/com/modals/ChangeHandle.tsx:253
 msgid "Handle"
-msgstr "Nome de usuario"
+msgstr "Alcume"
 
 #: src/view/screens/AccessibilitySettings.tsx:118
 msgid "Haptics"
-msgstr ""
+msgstr "Vibración"
 
 #: src/lib/moderation/useReportOptions.ts:34
 msgid "Harassment, trolling, or intolerance"
-msgstr "Acoso, troleo ou intolerancia"
+msgstr "Acoso, trolling ou intolerancia"
 
 #: src/Navigation.tsx:332
 msgid "Hashtag"
@@ -3274,28 +2972,20 @@ msgid "Help"
 msgstr "Axuda"
 
 #: src/screens/Onboarding/StepProfile/index.tsx:237
-msgid "Help people know you're not a bot by uploading a picture or creating an avatar."
-msgstr "Faille ver á xente que non es un bot subindo unha imaxe ou creando un avatar."
-
-#: src/screens/Onboarding/StepSuggestedAccounts/index.tsx:140
-#~ msgid "Here are some accounts for you to follow"
-#~ msgstr "Aquí tes algunhas contas a seguir"
-
-#: src/screens/Onboarding/StepTopicalFeeds.tsx:89
-#~ msgid "Here are some popular topical feeds. You can choose to follow as many as you like."
-#~ msgstr "Aquí tes algunhas fontes sobre actualicade máis populares. Podes seguir tantas como queiras."
-
-#: src/screens/Onboarding/StepTopicalFeeds.tsx:84
-#~ msgid "Here are some topical feeds based on your interests: {interestsText}. You can choose to follow as many as you like."
-#~ msgstr "Aquí tes algunhas fontes sobre actualidade baseadas nos teus intereses. {interestsText}. Podes seguir tantas como queiras."
+msgid ""
+"Help people know you're not a bot by uploading a picture or creating an "
+"avatar."
+msgstr ""
+"Axuda a que as persoas saiban que non es un bot subindo unha foto ou "
+"creando un avatar."
 
 #: src/view/com/modals/AddAppPasswords.tsx:204
 msgid "Here is your app password."
-msgstr "Aquí tes o teu contrasinal"
+msgstr "Aquí tes o teu contrasinal da app."
 
 #: src/components/ListCard.tsx:130
 msgid "Hidden list"
-msgstr "Lista oculta"
+msgstr "Listaxe oculta"
 
 #: src/components/moderation/ContentHider.tsx:178
 #: src/components/moderation/LabelPreference.tsx:134
@@ -3308,30 +2998,20 @@ msgstr "Lista oculta"
 msgid "Hide"
 msgstr "Ocultar"
 
-#: src/view/com/notifications/FeedItem.tsx:477
-msgctxt "action"
-msgid "Hide"
-msgstr "Ocultar"
-
-#: src/view/com/util/forms/PostDropdownBtn.tsx:390
-#: src/view/com/util/forms/PostDropdownBtn.tsx:392
-#~ msgid "Hide post"
-#~ msgstr "Ocultar publicación"
-
 #: src/view/com/util/forms/PostDropdownBtn.tsx:543
 #: src/view/com/util/forms/PostDropdownBtn.tsx:549
 msgid "Hide post for me"
-msgstr "Ocultar publicacións para min"
+msgstr "Ocultar o chío para min"
 
 #: src/view/com/util/forms/PostDropdownBtn.tsx:560
 #: src/view/com/util/forms/PostDropdownBtn.tsx:570
 msgid "Hide reply for everyone"
-msgstr ""
+msgstr "Ocultar rechouchío para todo o mundo"
 
 #: src/view/com/util/forms/PostDropdownBtn.tsx:542
 #: src/view/com/util/forms/PostDropdownBtn.tsx:548
 msgid "Hide reply for me"
-msgstr ""
+msgstr "Ocultar rechouchío para min"
 
 #: src/components/moderation/ContentHider.tsx:129
 #: src/components/moderation/PostHider.tsx:79
@@ -3340,48 +3020,72 @@ msgstr "Ocultar o contido"
 
 #: src/view/com/util/forms/PostDropdownBtn.tsx:679
 msgid "Hide this post?"
-msgstr "Ocultar esta publicación?"
+msgstr "Ocultar este chío?"
 
 #: src/view/com/util/forms/PostDropdownBtn.tsx:679
 #: src/view/com/util/forms/PostDropdownBtn.tsx:741
 msgid "Hide this reply?"
-msgstr "Ocultar esta resposta?"
+msgstr "Ocultar este rechouchío?"
 
 #: src/view/com/notifications/FeedItem.tsx:468
 msgid "Hide user list"
-msgstr "Ocultar a lista de usuarios"
+msgstr "Ocultar listaxe de persoas"
 
 #: src/view/com/posts/FeedErrorMessage.tsx:117
-msgid "Hmm, some kind of issue occurred when contacting the feed server. Please let the feed owner know about this issue."
-msgstr "Produciuse algún tipo de problema ao contactar co servidor de fontes. Por favor, informa ao propietario do problema."
+msgid ""
+"Hmm, some kind of issue occurred when contacting the feed server. Please "
+"let the feed owner know about this issue."
+msgstr ""
+"Produciuse algún problema ao contactar co servidos das canles. Por favor, "
+"informa á persoa autora da nova sobre este problema."
 
 #: src/view/com/posts/FeedErrorMessage.tsx:105
-msgid "Hmm, the feed server appears to be misconfigured. Please let the feed owner know about this issue."
-msgstr "Semella que servidor de fontes non está ben configurado. Por favor, informa ao propietario do problema."
+msgid ""
+"Hmm, the feed server appears to be misconfigured. Please let the feed owner "
+"know about this issue."
+msgstr ""
+"Parece que o servidor das canles está mal configurado. Por favor, informa á "
+"persoa autora da nova sobre este problema."
 
 #: src/view/com/posts/FeedErrorMessage.tsx:111
-msgid "Hmm, the feed server appears to be offline. Please let the feed owner know about this issue."
-msgstr "O servidor de fontes semella estar fora de liña. Por favor, informa ao propietario do problema."
+msgid ""
+"Hmm, the feed server appears to be offline. Please let the feed owner know "
+"about this issue."
+msgstr ""
+"Parece que o servidor das canles non está en liña. Por favor, informa á "
+"persoa autora da nova sobre este problema."
 
 #: src/view/com/posts/FeedErrorMessage.tsx:108
-msgid "Hmm, the feed server gave a bad response. Please let the feed owner know about this issue."
-msgstr "O servidor de fontes respondeu de xeito incorrecto. Por favor, informa ao propietario da fonte sobre o problema."
+msgid ""
+"Hmm, the feed server gave a bad response. Please let the feed owner know "
+"about this issue."
+msgstr ""
+"O servidor das canles respondeu de forma incorrecta. Por favor, informa á "
+"persoa autora da nova sobre este problema."
 
 #: src/view/com/posts/FeedErrorMessage.tsx:102
 msgid "Hmm, we're having trouble finding this feed. It may have been deleted."
-msgstr "Estamos a ter problemas para atopar esta fonte. É posíbel que a elimininaran."
+msgstr "Temos problemas para encontrar esta canle. Pode ser que a borrasen."
 
 #: src/screens/Moderation/index.tsx:61
-msgid "Hmmmm, it seems we're having trouble loading this data. See below for more details. If this issue persists, please contact us."
-msgstr "Semella que temos problema para cargar estes datos. Ver a continuación os detalles. Se o problema persiste, por favor contacta connosco."
+msgid ""
+"Hmmmm, it seems we're having trouble loading this data. See below for more "
+"details. If this issue persists, please contact us."
+msgstr ""
+"Vaites! Parece que temos problemas para cargar estes datos. Consulta máis "
+"detalles a continuación. Se o problema persiste, ponte en contacto connosco."
 
 #: src/screens/Profile/ErrorState.tsx:31
 msgid "Hmmmm, we couldn't load that moderation service."
-msgstr "Non foi posíbel iniciar o servizo de moderación."
+msgstr "Vaites! Non puidemos cargar ese servizo de moderación."
 
 #: src/view/com/composer/state/video.ts:427
-msgid "Hold up! We’re gradually giving access to video, and you’re still waiting in line. Check back soon!"
-msgstr "Agarda! Estamos a dar acceso ao vídeo aos poucos, e aínda estás na cola. Volve consultar nun intre!"
+msgid ""
+"Hold up! We’re gradually giving access to video, and you’re still waiting "
+"in line. Check back soon!"
+msgstr ""
+"Espera! Estamos dando acceso a vídeos gradualmente e aínda estás na listaxe "
+"de espera. Volve a consultar máis adiante."
 
 #: src/Navigation.tsx:549
 #: src/Navigation.tsx:569
@@ -3389,22 +3093,22 @@ msgstr "Agarda! Estamos a dar acceso ao vídeo aos poucos, e aínda estás na co
 #: src/view/shell/desktop/LeftNav.tsx:369
 #: src/view/shell/Drawer.tsx:420
 msgid "Home"
-msgstr ""
+msgstr "Inicio"
 
 #: src/view/com/modals/ChangeHandle.tsx:407
 msgid "Host:"
-msgstr "Host:"
+msgstr "Aloxamento:"
 
 #: src/screens/Login/ForgotPasswordForm.tsx:83
 #: src/screens/Login/LoginForm.tsx:166
 #: src/screens/Signup/StepInfo/index.tsx:133
 #: src/view/com/modals/ChangeHandle.tsx:268
 msgid "Hosting provider"
-msgstr "Provedor de hospedaxe"
+msgstr "Proveedor de aloxamento"
 
 #: src/view/com/modals/InAppBrowserConsent.tsx:41
 msgid "How should we open this link?"
-msgstr ""
+msgstr "Como deberíamos abrir esta ligazón?"
 
 #: src/view/com/modals/VerifyEmail.tsx:222
 #: src/view/screens/Settings/DisableEmail2FADialog.tsx:131
@@ -3428,35 +3132,45 @@ msgstr "Teño o meu propio dominio"
 #: src/components/dms/BlockedByListDialog.tsx:57
 #: src/components/dms/ReportConversationPrompt.tsx:22
 msgid "I understand"
-msgstr "Entendo"
+msgstr "Enténdoo"
 
 #: src/view/com/lightbox/Lightbox.web.tsx:185
 msgid "If alt text is long, toggles alt text expanded state"
-msgstr "Se o texto alternativo é longo, alterna o estado expandido deste."
-
-#: src/view/com/modals/SelfLabel.tsx:128
-#~ msgid "If none are selected, suitable for all ages."
-#~ msgstr "Se non hai ningún seleccionado, é adecuado para todas as idades."
+msgstr ""
+"Se o texto alternativo é longo, alterna o estado expandido do texto "
+"alternativo. "
 
 #: src/screens/Signup/StepInfo/Policies.tsx:110
-msgid "If you are not yet an adult according to the laws of your country, your parent or legal guardian must read these Terms on your behalf."
-msgstr "Se aínda non es adulto segundo as leis do teu país, os teus pais ou titor legal deben ler os Termos no teu nome."
+msgid ""
+"If you are not yet an adult according to the laws of your country, your "
+"parent or legal guardian must read these Terms on your behalf."
+msgstr ""
+"Se aínda non es maior de idade segundo as leis do teu país, o teu pai, a "
+"túa nai ou o teu titor legal debe ler estes Termos no teu nome."
 
 #: src/view/screens/ProfileList.tsx:723
 msgid "If you delete this list, you won't be able to recover it."
-msgstr "Se eliminas a lista, non a poderás recuperar."
+msgstr "Se eliminas esta listaxe, non poderás recuperala."
 
 #: src/view/com/util/forms/PostDropdownBtn.tsx:670
 msgid "If you remove this post, you won't be able to recover it."
-msgstr "Se eliminas esta publicación, non a poderás recuperar."
+msgstr "Se eliminas este chío, non poderás recuperalo."
 
 #: src/view/com/modals/ChangePassword.tsx:149
-msgid "If you want to change your password, we will send you a code to verify that this is your account."
-msgstr "Se queres mudar o contrasinal, enviarémosche un código para verificar que é a túa conta."
+msgid ""
+"If you want to change your password, we will send you a code to verify that "
+"this is your account."
+msgstr ""
+"Se desexas cambiar o teu contrasinal, enviarémosche un código para "
+"verificar que esta é a túa conta."
 
 #: src/screens/Settings/components/DeactivateAccountDialog.tsx:92
-msgid "If you're trying to change your handle or email, do so before you deactivate."
-msgstr "Se estás a mudar o teu nome de usuario ou correo, fai isto antes de desactivala."
+msgid ""
+"If you're trying to change your handle or email, do so before you "
+"deactivate."
+msgstr ""
+"Se estás intentando cambiar o teu alcume ou enderezo electrónico, faino "
+"antes de desactivar a túa conta."
 
 #: src/lib/moderation/useReportOptions.ts:38
 msgid "Illegal and Urgent"
@@ -3466,103 +3180,97 @@ msgstr "Ilegal e Urxente"
 msgid "Image"
 msgstr "Imaxe"
 
-#: src/view/com/modals/AltImage.tsx:122
-#~ msgid "Image alt text"
-#~ msgstr "Texto alternativo da imaxe"
-
 #: src/components/StarterPack/ShareDialog.tsx:77
 msgid "Image saved to your camera roll!"
-msgstr "Imaxe gardada na túa galería!"
+msgstr "Imaxe gardada no teu carrete de fotos!"
 
 #: src/lib/moderation/useReportOptions.ts:49
 msgid "Impersonation or false claims about identity or affiliation"
 msgstr ""
+"Suplantación de identidade ou afirmacións falsas sobre identidade ou "
+"afiliación"
 
 #: src/lib/moderation/useReportOptions.ts:68
 msgid "Impersonation, misinformation, or false claims"
-msgstr ""
+msgstr "Suplantación de identidade, desinformación ou afirmacións falsas"
 
 #: src/lib/moderation/useReportOptions.ts:91
 msgid "Inappropriate messages or explicit links"
-msgstr "Mensaxes inapropiadas ou ligazóns a contido explicito"
+msgstr "Mensaxes inapropiadas ou ligazóns explícitas"
 
 #: src/screens/Login/SetNewPasswordForm.tsx:121
 msgid "Input code sent to your email for password reset"
-msgstr "Insire o código enviado ao teu correo para restablecer o contrasinal"
+msgstr ""
+"Introduce o código enviado ao teu correo electrónico para restablecer o "
+"contrasinal"
 
 #: src/view/com/modals/DeleteAccount.tsx:246
 msgid "Input confirmation code for account deletion"
-msgstr "Insire o código de confirmación para eliminar a conta"
+msgstr "Introduce o código de confirmación para eliminar a conta"
 
 #: src/view/com/modals/AddAppPasswords.tsx:175
 msgid "Input name for app password"
-msgstr "Insire un nome para o contrasinal"
+msgstr "Introduce un nome para o contrasinal da aplicación"
 
 #: src/screens/Login/SetNewPasswordForm.tsx:145
 msgid "Input new password"
-msgstr "Insire un novo contrasinal"
+msgstr "Introduce un novo contrasinal"
 
 #: src/view/com/modals/DeleteAccount.tsx:265
 msgid "Input password for account deletion"
-msgstr "Insire o contrasinal para eliminar a conta"
+msgstr "Introduce o contrasinal para eliminar a conta"
 
 #: src/screens/Login/LoginForm.tsx:270
 msgid "Input the code which has been emailed to you"
-msgstr "Insire o código que recibiches por correo"
-
-#: src/screens/Login/LoginForm.tsx:221
-#~ msgid "Input the password tied to {identifier}"
-#~ msgstr "Insire o contrasinal asociado a {identifier}"
+msgstr "Introduce o código que se che enviou por correo electrónico"
 
 #: src/screens/Login/LoginForm.tsx:200
 msgid "Input the username or email address you used at signup"
-msgstr "Insire o nome de usuario e o enderezo de correo que usaches ao rexistrarte"
+msgstr ""
+"Introduce o alcume ou o enderezo de correo electrónico que usaches ao "
+"rexistrarte"
 
 #: src/screens/Login/LoginForm.tsx:225
 msgid "Input your password"
-msgstr "Insire o contrasinal"
+msgstr "Introduce o teu contrasinal"
 
 #: src/view/com/modals/ChangeHandle.tsx:376
 msgid "Input your preferred hosting provider"
-msgstr "Insire o teu provedor de hospedaxe preferido"
+msgstr "Introduce o teu proveedor de aloxamento preferido"
 
 #: src/screens/Signup/StepHandle.tsx:114
 msgid "Input your user handle"
-msgstr "Insire o teu nome de usuario"
+msgstr "Introduce o teu alcume"
 
 #: src/view/com/composer/threadgate/ThreadgateBtn.tsx:50
 msgid "Interaction limited"
 msgstr "Interacción limitada"
 
-#: src/components/dms/MessagesNUX.tsx:82
-#~ msgid "Introducing Direct Messages"
-#~ msgstr "Presentando as Mensaxes Directas"
-
 #: src/components/dialogs/nuxs/NeueTypography.tsx:47
 msgid "Introducing new font settings"
-msgstr "Presentando novos axustes de fontes"
+msgstr "Presentamos novas configuracións das fontes"
 
 #: src/screens/Login/LoginForm.tsx:142
 #: src/view/screens/Settings/DisableEmail2FADialog.tsx:70
 msgid "Invalid 2FA confirmation code."
-msgstr "Código de confirmación 2FA non válido."
+msgstr "O código de confirmación 2FA non é válido."
 
 #: src/view/com/post-thread/PostThreadItem.tsx:264
 msgid "Invalid or unsupported post record"
-msgstr "Rexistro de publicación inválido ou non compatíbel"
+msgstr "Rexistro de chío inválido ou non compatíbel"
 
 #: src/screens/Login/LoginForm.tsx:88
 #: src/screens/Login/LoginForm.tsx:147
 msgid "Invalid username or password"
-msgstr "Nome de usuario ou contrasinal non válidos"
+msgstr "Alcume ou contrasinal incorrectos"
 
 #: src/components/intents/VerifyEmailIntentDialog.tsx:91
 msgid "Invalid Verification Code"
-msgstr "Código de verificación non válido"
+msgstr "O Código de Verificación incorrecto"
 
 #: src/view/com/modals/InviteCodes.tsx:94
 msgid "Invite a Friend"
-msgstr "Convida a un amigo"
+msgstr "Convida a unha amizade"
 
 #: src/screens/Signup/StepInfo/index.tsx:151
 msgid "Invite code"
@@ -3570,7 +3278,9 @@ msgstr "Código de convite"
 
 #: src/screens/Signup/state.ts:258
 msgid "Invite code not accepted. Check that you input it correctly and try again."
-msgstr "Código de convite non aceptado. Comproba que é correcto e téntao de novo."
+msgstr ""
+"Non se acepta o código de convite. Comproba que o introduciches "
+"correctamente e inténtao de novo."
 
 #: src/view/com/modals/InviteCodes.tsx:171
 msgid "Invite codes: {0} available"
@@ -3578,39 +3288,43 @@ msgstr "Códigos de convite: {0} dispoñíbeis"
 
 #: src/view/com/modals/InviteCodes.tsx:170
 msgid "Invite codes: 1 available"
-msgstr "Códigos de convite: 1 dispoñíbel"
+msgstr "Códigos de convite: 1 disponíbel"
 
 #: src/components/StarterPack/ShareDialog.tsx:97
 msgid "Invite people to this starter pack!"
-msgstr "Convidar a xente a este paquete de inicio!"
+msgstr "Convida a persoas a este paquete inicial!"
 
 #: src/screens/StarterPack/Wizard/StepDetails.tsx:35
 msgid "Invite your friends to follow your favorite feeds and people"
-msgstr "Convida aos teus amigos a seguir as túas fontes e xente favoritas"
+msgstr "Convida ás túas amizades a seguir as túas canles e persoas favoritas"
 
 #: src/screens/StarterPack/Wizard/StepDetails.tsx:32
 msgid "Invites, but personal"
-msgstr ""
+msgstr "Convites, mais personais"
 
 #: src/screens/Signup/StepInfo/index.tsx:80
-msgid "It looks like you may have entered your email address incorrectly. Are you sure it's right?"
-msgstr "Semella que inseriches o teu correo electrónico de xeito incorrecto. Estás certo/a de que é correcto?"
-
-#: src/screens/Onboarding/StepFollowingFeed.tsx:65
-#~ msgid "It shows posts from the people you follow as they happen."
-#~ msgstr ""
+msgid ""
+"It looks like you may have entered your email address incorrectly. Are you "
+"sure it's right?"
+msgstr ""
+"Parece que poderías ter ingresado o teu enderezo electrónico "
+"incorrectamente. Tes a certeza de que é correcta?"
 
 #: src/screens/Signup/StepInfo/index.tsx:241
 msgid "It's correct"
 msgstr "É correcto"
 
 #: src/screens/StarterPack/Wizard/index.tsx:461
-msgid "It's just you right now! Add more people to your starter pack by searching above."
-msgstr "Só estás ti agora mesmo! Engade máis xente ao teu paquete de inicio."
+msgid ""
+"It's just you right now! Add more people to your starter pack by searching "
+"above."
+msgstr ""
+"Por agora só estás ti! Engade máis persoas ao teu paquete inicial buscando "
+"arriba."
 
 #: src/view/com/composer/Composer.tsx:1284
 msgid "Job ID: {0}"
-msgstr "ID da tarefa: {0}"
+msgstr "Tarefa ID: {0}"
 
 #: src/view/com/auth/SplashScreen.web.tsx:177
 msgid "Jobs"
@@ -3621,25 +3335,17 @@ msgstr "Tarefas"
 #: src/screens/StarterPack/StarterPackScreen.tsx:454
 #: src/screens/StarterPack/StarterPackScreen.tsx:465
 msgid "Join Bluesky"
-msgstr "Únete ao Bluesky"
+msgstr "Únete a Bluesky"
 
 #: src/components/StarterPack/QrCode.tsx:61
 #: src/view/shell/NavSignupCard.tsx:40
 msgid "Join the conversation"
-msgstr "Unirse á conversa"
-
-#: src/components/dialogs/nuxs/TenMillion/index.tsx:492
-#~ msgid "Joined {0}"
-#~ msgstr "Unido/a {0}"
+msgstr "Únete á conversa"
 
 #: src/screens/Onboarding/index.tsx:21
 #: src/screens/Onboarding/state.ts:91
 msgid "Journalism"
 msgstr "Xornalismo"
-
-#: src/components/moderation/LabelsOnMe.tsx:59
-#~ msgid "label has been placed on this {labelTarget}"
-#~ msgstr ""
 
 #: src/components/moderation/ContentHider.tsx:209
 msgid "Labeled by {0}."
@@ -3647,7 +3353,7 @@ msgstr "Etiquetado por {0}."
 
 #: src/components/moderation/ContentHider.tsx:207
 msgid "Labeled by the author."
-msgstr "Etiquetado polo autor."
+msgstr "Etiquetado pola persoa autora."
 
 #: src/view/com/composer/labels/LabelsBtn.tsx:76
 #: src/view/screens/Profile.tsx:226
@@ -3659,12 +3365,12 @@ msgid "Labels added"
 msgstr "Etiquetas engadidas"
 
 #: src/screens/Profile/Sections/Labels.tsx:163
-msgid "Labels are annotations on users and content. They can be used to hide, warn, and categorize the network."
-msgstr "As etiquetas son anotacións en usuarios e contido. Poden ser usadas para ocultar, avisar e categorizar a rede."
-
-#: src/components/moderation/LabelsOnMe.tsx:61
-#~ msgid "labels have been placed on this {labelTarget}"
-#~ msgstr ""
+msgid ""
+"Labels are annotations on users and content. They can be used to hide, "
+"warn, and categorize the network."
+msgstr ""
+"As etiquetas son anotacións sobre persoas e contido. Poden usarse para "
+"ocultar, advertir e categorizar a rede."
 
 #: src/components/moderation/LabelsOnMeDialog.tsx:71
 msgid "Labels on your account"
@@ -3676,71 +3382,71 @@ msgstr "Etiquetas no teu contido"
 
 #: src/view/com/composer/select-language/SelectLangBtn.tsx:105
 msgid "Language selection"
-msgstr "Selección de lingua"
+msgstr "Escoller idioma"
 
 #: src/view/screens/Settings/index.tsx:497
 msgid "Language settings"
-msgstr "Axustes de lingua"
+msgstr "Axustes de idiomas"
 
 #: src/Navigation.tsx:159
 #: src/view/screens/LanguageSettings.tsx:88
 msgid "Language Settings"
-msgstr "Axustes de Lingua"
+msgstr "Axustes de Idiomas"
 
 #: src/view/screens/Settings/index.tsx:506
 msgid "Languages"
-msgstr "Linguas"
+msgstr "Idiomas"
 
 #: src/components/dialogs/nuxs/NeueTypography.tsx:103
 #: src/screens/Settings/AppearanceSettings.tsx:173
 msgid "Larger"
-msgstr ""
+msgstr "Máis grande"
 
 #: src/screens/Hashtag.tsx:98
 #: src/view/screens/Search/Search.tsx:521
 msgid "Latest"
-msgstr ""
+msgstr "Último"
 
 #: src/components/moderation/ScreenHider.tsx:140
 msgid "Learn More"
-msgstr "Saber Máis"
+msgstr "Aprender máis"
 
 #: src/view/com/auth/SplashScreen.web.tsx:165
 msgid "Learn more about Bluesky"
-msgstr "Saber máis sobre BluesKy"
+msgstr "Aprender máis de Bluesky"
 
 #: src/view/com/auth/server-input/index.tsx:156
 msgid "Learn more about self hosting your PDS."
-msgstr ""
+msgstr "Obtén máis información sobre como aloxar o teu PDS."
 
 #: src/components/moderation/ContentHider.tsx:127
 #: src/components/moderation/ContentHider.tsx:193
 msgid "Learn more about the moderation applied to this content."
-msgstr "Saber máis sobre a moderación aplicada a este contido."
+msgstr "Obtén máis información sobre a moderación aplicada a este contido."
 
 #: src/components/moderation/PostHider.tsx:100
 #: src/components/moderation/ScreenHider.tsx:127
 msgid "Learn more about this warning"
-msgstr "Saber máis sobre este aviso"
+msgstr "Aprender máis sobre esta advertencia"
 
 #: src/screens/Moderation/index.tsx:587
 #: src/screens/Moderation/index.tsx:589
 msgid "Learn more about what is public on Bluesky."
-msgstr "Saber máis sobre a parte pública no Bluesky."
+msgstr "Máis información sobre o que é público en Bluesky."
 
 #: src/components/moderation/ContentHider.tsx:217
 #: src/view/com/auth/server-input/index.tsx:158
 msgid "Learn more."
-msgstr "Saber máis."
+msgstr "Aprender máis."
 
 #: src/components/dms/LeaveConvoPrompt.tsx:50
 msgid "Leave"
-msgstr "Saír"
+msgstr "Deixar"
 
 #: src/components/dms/MessagesListBlockedFooter.tsx:66
 #: src/components/dms/MessagesListBlockedFooter.tsx:73
 msgid "Leave chat"
-msgstr "Saír da conversa"
+msgstr "Deixar conversa"
 
 #: src/components/dms/ConvoMenu.tsx:138
 #: src/components/dms/ConvoMenu.tsx:141
@@ -3748,23 +3454,19 @@ msgstr "Saír da conversa"
 #: src/components/dms/ConvoMenu.tsx:211
 #: src/components/dms/LeaveConvoPrompt.tsx:46
 msgid "Leave conversation"
-msgstr "Saír da conversa"
+msgstr "Deixar conversación"
 
 #: src/view/com/modals/lang-settings/ContentLanguagesSettings.tsx:83
 msgid "Leave them all unchecked to see any language."
-msgstr "Deixar sen marcar para ver calquea lingua."
+msgstr "Déixaos todos sen marcar para ver calquera idioma."
 
 #: src/view/com/modals/LinkWarning.tsx:65
 msgid "Leaving Bluesky"
-msgstr "Saíndo do Bluesky"
+msgstr "Saír de Bluesky"
 
 #: src/screens/SignupQueued.tsx:134
 msgid "left to go."
-msgstr "imos aló."
-
-#: src/view/screens/Settings/index.tsx:310
-#~ msgid "Legacy storage cleared, you need to restart the app now."
-#~ msgstr "Almacenamento herdado eliminado, é preciso reiniciar agora."
+msgstr "queda por ir."
 
 #: src/components/StarterPack/ProfileStarterPacks.tsx:296
 msgid "Let me choose"
@@ -3777,29 +3479,25 @@ msgstr "Imos restablecer o teu contrasinal!"
 
 #: src/screens/Onboarding/StepFinished.tsx:287
 msgid "Let's go!"
-msgstr "Imos aló!"
+msgstr "Imos!"
 
 #: src/screens/Settings/AppearanceSettings.tsx:105
 msgid "Light"
 msgstr "Claro"
 
-#: src/view/com/util/post-ctrls/PostCtrls.tsx:197
-#~ msgid "Like"
-#~ msgstr "Gústame"
-
 #: src/components/ProgressGuide/List.tsx:48
 msgid "Like 10 posts"
-msgstr "Dálle a «gústame» en 10 publicacións"
+msgstr "Dálle «gústame» a 10 chíos"
 
 #: src/state/shell/progress-guide.tsx:157
 #: src/state/shell/progress-guide.tsx:162
 msgid "Like 10 posts to train the Discover feed"
-msgstr "Dálle a «gústame» en 10 publicacións para adestrar ao descubridor de fontes"
+msgstr "Dálle «gústame» a 10 publicacións para entrenar as canles de Descubrimento."
 
 #: src/screens/Profile/Header/ProfileHeaderLabeler.tsx:265
 #: src/view/screens/ProfileFeed.tsx:576
 msgid "Like this feed"
-msgstr "Dálle a «gústame» nesta fonte"
+msgstr "Dar «gústame» a esta canle"
 
 #: src/components/LikesDialog.tsx:85
 #: src/Navigation.tsx:230
@@ -3814,27 +3512,13 @@ msgstr "Gustoulle a"
 msgid "Liked By"
 msgstr "Gustoulle a"
 
-#: src/view/com/feeds/FeedSourceCard.tsx:268
-#~ msgid "Liked by {0} {1}"
-#~ msgstr "Gustoulle a {0} {1}"
-
-#: src/components/LabelingServiceCard/index.tsx:72
-#~ msgid "Liked by {count} {0}"
-#~ msgstr "Gustoulle a {count} {0}"
-
-#: src/screens/Profile/Header/ProfileHeaderLabeler.tsx:287
-#: src/screens/Profile/Header/ProfileHeaderLabeler.tsx:301
-#: src/view/screens/ProfileFeed.tsx:600
-#~ msgid "Liked by {likeCount} {0}"
-#~ msgstr "Gustoulee a {likeCount} {0}"
-
 #: src/view/com/notifications/FeedItem.tsx:211
 msgid "liked your custom feed"
-msgstr "gustoulle a túa fonte personalizada"
+msgstr "gústanlle as túas canles personalizadas"
 
 #: src/view/com/notifications/FeedItem.tsx:178
 msgid "liked your post"
-msgstr "gustoulle a túa publicación"
+msgstr "gústalle o teu chío"
 
 #: src/view/screens/Profile.tsx:231
 msgid "Likes"
@@ -3842,52 +3526,52 @@ msgstr "Gústame"
 
 #: src/view/com/post-thread/PostThreadItem.tsx:204
 msgid "Likes on this post"
-msgstr "Gústame nesta publicación"
+msgstr "Gústame en este chío"
 
 #: src/Navigation.tsx:192
 msgid "List"
-msgstr "Lista"
+msgstr "Listaxe"
 
 #: src/view/com/modals/CreateOrEditList.tsx:241
 msgid "List Avatar"
-msgstr "Avatar da lista"
+msgstr "Avatar da listaxe"
 
 #: src/view/screens/ProfileList.tsx:422
 msgid "List blocked"
-msgstr "Lista bloqueada"
+msgstr "Listaxe de bloqueados"
 
 #: src/components/ListCard.tsx:150
 #: src/view/com/feeds/FeedSourceCard.tsx:252
 msgid "List by {0}"
-msgstr "Lista por {0}"
+msgstr "Listaxe por {0}"
 
 #: src/view/screens/ProfileList.tsx:459
 msgid "List deleted"
-msgstr "Lista eliminada"
+msgstr "Listaxe de eliminados"
 
 #: src/screens/List/ListHiddenScreen.tsx:126
 msgid "List has been hidden"
-msgstr "Lista ocultada"
+msgstr "Ocultouse a listaxe"
 
 #: src/view/screens/ProfileList.tsx:170
 msgid "List Hidden"
-msgstr "Lista oculta"
+msgstr "Listaxe oculta"
 
 #: src/view/screens/ProfileList.tsx:396
 msgid "List muted"
-msgstr "Lista silenciada"
+msgstr "Listaxe silenciada"
 
 #: src/view/com/modals/CreateOrEditList.tsx:255
 msgid "List Name"
-msgstr "Nome da lista"
+msgstr "Nome da listaxe"
 
 #: src/view/screens/ProfileList.tsx:435
 msgid "List unblocked"
-msgstr "Lista desbloqueada"
+msgstr "Listaxe desbloqueada"
 
 #: src/view/screens/ProfileList.tsx:409
 msgid "List unmuted"
-msgstr ""
+msgstr "A listaxe xa non está silenciada"
 
 #: src/Navigation.tsx:129
 #: src/view/screens/Profile.tsx:227
@@ -3895,11 +3579,11 @@ msgstr ""
 #: src/view/shell/desktop/LeftNav.tsx:407
 #: src/view/shell/Drawer.tsx:520
 msgid "Lists"
-msgstr "Listas"
+msgstr "Listaxes"
 
 #: src/components/dms/BlockedByListDialog.tsx:39
 msgid "Lists blocking this user:"
-msgstr "Listas que bloquean este usuario:"
+msgstr "Listaxes que bloquean a esta persoa:"
 
 #: src/view/screens/Search/Explore.tsx:131
 msgid "Load more"
@@ -3907,22 +3591,22 @@ msgstr "Cargar máis"
 
 #: src/view/screens/Search/Explore.tsx:219
 msgid "Load more suggested feeds"
-msgstr "Cargar máis fontes suxeridas"
+msgstr "Cargar máis canles suxeridas"
 
 #: src/view/screens/Search/Explore.tsx:217
 msgid "Load more suggested follows"
-msgstr ""
+msgstr "Cargar máis seguidos suxeridos"
 
 #: src/view/screens/Notifications.tsx:215
 msgid "Load new notifications"
-msgstr "Cargar novas notificacións"
+msgstr "Cargar notificacións novas"
 
 #: src/screens/Profile/Sections/Feed.tsx:96
 #: src/view/com/feeds/FeedPage.tsx:132
 #: src/view/screens/ProfileFeed.tsx:499
 #: src/view/screens/ProfileList.tsx:808
 msgid "Load new posts"
-msgstr "Cargar novas publicacións"
+msgstr "Cargar novos chíos"
 
 #: src/view/com/composer/text-input/mobile/Autocomplete.tsx:111
 msgid "Loading..."
@@ -3930,7 +3614,7 @@ msgstr "Cargando..."
 
 #: src/Navigation.tsx:255
 msgid "Log"
-msgstr "Rexisto"
+msgstr "Rexistro"
 
 #: src/screens/Deactivated.tsx:214
 #: src/screens/Deactivated.tsx:220
@@ -3946,77 +3630,85 @@ msgstr "Saír"
 
 #: src/screens/Moderation/index.tsx:480
 msgid "Logged-out visibility"
-msgstr ""
+msgstr "Visibilidade de desconexión"
 
 #: src/components/AccountList.tsx:65
 msgid "Login to account that is not listed"
-msgstr ""
+msgstr "Acceder a unha conta que non está na listaxe"
 
 #: src/view/shell/desktop/RightNav.tsx:104
 msgid "Logo by <0/>"
-msgstr "Logotipo por <0/>"
+msgstr "Logo por <0/>"
 
 #: src/view/shell/Drawer.tsx:296
 msgid "Logo by <0>@sawaratsuki.bsky.social</0>"
-msgstr "Logotipo por <0>@sawaratsuki.bsky.social</0>"
+msgstr "Logo por <0>@sawaratsuki.bsky.social</0>"
 
 #: src/components/RichText.tsx:226
 msgid "Long press to open tag menu for #{tag}"
-msgstr "Premer e manter para abrir o menú de etiquetas para #{tag}"
+msgstr "Mantén presionado para abrir o menú de etiquetas para #{tag}"
 
 #: src/screens/Login/SetNewPasswordForm.tsx:110
 msgid "Looks like XXXXX-XXXXX"
-msgstr "Semella XXXXX-XXXXX"
+msgstr "É como XXXXX-XXXXX"
 
 #: src/screens/Feeds/NoSavedFeedsOfAnyType.tsx:39
-msgid "Looks like you haven't saved any feeds! Use our recommendations or browse more below."
-msgstr "Semella que non gardaches ningunha fonte! Usa as nosas recomendacións ou procura abaixo máis"
+msgid ""
+"Looks like you haven't saved any feeds! Use our recommendations or browse "
+"more below."
+msgstr ""
+"Parece que non gardaches ningunha canle. Usa as nosas recomendacións ou "
+"busca máis abaixo."
 
 #: src/screens/Home/NoFeedsPinned.tsx:83
-msgid "Looks like you unpinned all your feeds. But don't worry, you can add some below 😄"
-msgstr "Semella que desfixaste todas as túas fontes. Mais acouga, podes engadir algunhas abaixo 😄"
-
-#: src/screens/Feeds/NoFollowingFeed.tsx:38
-#~ msgid "Looks like you're missing a following feed."
-#~ msgstr "Semella que esqueciches a seguinte fonte."
+msgid ""
+"Looks like you unpinned all your feeds. But don't worry, you can add some "
+"below 😄"
+msgstr ""
+"Parece que desfixaches todas as túas canles. Mais non te preocupes, podes "
+"agregar algunhas máis abaixo 😄"
 
 #: src/screens/Feeds/NoFollowingFeed.tsx:37
 msgid "Looks like you're missing a following feed. <0>Click here to add one.</0>"
-msgstr "Semella que esqueciches a seguinte fonte. <0>Clic aquí para engadir unha.</0>"
+msgstr ""
+"Parece que che falta unha canle de seguimento. <0>Preme aquí para agregar "
+"unha</0>"
 
 #: src/components/StarterPack/ProfileStarterPacks.tsx:255
 msgid "Make one for me"
-msgstr "Facer un por min"
+msgstr "Fai un para min"
 
 #: src/view/com/modals/LinkWarning.tsx:79
 msgid "Make sure this is where you intend to go!"
-msgstr "Asegúrate de que é aquí onde queres ir!"
+msgstr "Asegúrate de que este é o lugar onde queres ir!"
 
 #: src/components/dialogs/MutedWords.tsx:108
 msgid "Manage your muted words and tags"
-msgstr "Xestina as túas palabras e etiquetas silenciadas"
+msgstr "Xestiona as túas palabras e etiquetas silenciadas"
 
 #: src/components/dms/ConvoMenu.tsx:151
 #: src/components/dms/ConvoMenu.tsx:158
 msgid "Mark as read"
-msgstr "Marcar coma lido"
+msgstr "Marcar como lido"
 
 #: src/view/screens/AccessibilitySettings.tsx:104
 #: src/view/screens/Profile.tsx:230
 msgid "Media"
-msgstr "Medios"
+msgstr "Multimedia"
 
 #: src/view/com/composer/labels/LabelsBtn.tsx:208
 msgid "Media that may be disturbing or inappropriate for some audiences."
-msgstr "Medios que poden ser molestos ou inapropiados para algúns públicos."
+msgstr ""
+"Medios que poden resultar perturbadores ou inapropiados para algunhas "
+"audiencias."
 
 #: src/components/WhoCanReply.tsx:254
 msgid "mentioned users"
-msgstr "usuarios mencionados"
+msgstr "persoas mencionadas"
 
 #: src/components/dialogs/PostInteractionSettingsDialog.tsx:394
 msgid "Mentioned users"
-msgstr "Usuarios mencionados"
+msgstr "Persoas mencionadas"
 
 #: src/components/Menu/index.tsx:94
 #: src/view/com/util/ViewHeader.tsx:87
@@ -4044,11 +3736,11 @@ msgstr "Campo de entrada da mensaxe"
 #: src/screens/Messages/components/MessageInput.tsx:72
 #: src/screens/Messages/components/MessageInput.web.tsx:59
 msgid "Message is too long"
-msgstr "A mensaxe é longa de máis"
+msgstr "A mensaxe é demasiado longa"
 
 #: src/screens/Messages/ChatList.tsx:318
 msgid "Message settings"
-msgstr "Axustes de mensaxe"
+msgstr "Axustes de mensaxes"
 
 #: src/Navigation.tsx:564
 #: src/screens/Messages/ChatList.tsx:162
@@ -4057,21 +3749,13 @@ msgstr "Axustes de mensaxe"
 msgid "Messages"
 msgstr "Mensaxes"
 
-#: src/Navigation.tsx:307
-#~ msgid "Messaging settings"
-#~ msgstr "Axustes de mensaxes"
-
 #: src/lib/moderation/useReportOptions.ts:47
 msgid "Misleading Account"
 msgstr "Conta enganosa"
 
 #: src/lib/moderation/useReportOptions.ts:67
 msgid "Misleading Post"
-msgstr "Publicación enganosa"
-
-#: src/screens/Settings/AppearanceSettings.tsx:78
-#~ msgid "Mode"
-#~ msgstr "Modo"
+msgstr "Chío enganoso"
 
 #: src/Navigation.tsx:134
 #: src/screens/Moderation/index.tsx:107
@@ -4086,33 +3770,33 @@ msgstr "Detalles de moderación"
 #: src/components/ListCard.tsx:149
 #: src/view/com/modals/UserAddRemoveLists.tsx:222
 msgid "Moderation list by {0}"
-msgstr "Lista de moderación por {0}"
+msgstr "Listaxe de moderación feita por {0}"
 
 #: src/view/screens/ProfileList.tsx:902
 msgid "Moderation list by <0/>"
-msgstr "Lista de moderación por <0/>"
+msgstr "Listaxe de moderación feita por <0/>"
 
 #: src/view/com/modals/UserAddRemoveLists.tsx:220
 #: src/view/screens/ProfileList.tsx:900
 msgid "Moderation list by you"
-msgstr "Lista de moderación para ti"
+msgstr "Listaxe de moderación feita por ti"
 
 #: src/view/com/modals/CreateOrEditList.tsx:177
 msgid "Moderation list created"
-msgstr "Lista de moderación creada"
+msgstr "Listaxe de moderación creada"
 
 #: src/view/com/modals/CreateOrEditList.tsx:163
 msgid "Moderation list updated"
-msgstr "Lista de moderación actualizada"
+msgstr "Listaxe de moderación actualizada"
 
 #: src/screens/Moderation/index.tsx:250
 msgid "Moderation lists"
-msgstr "Listas de moderación"
+msgstr "Listaxes de moderación"
 
 #: src/Navigation.tsx:139
 #: src/view/screens/ModerationModlists.tsx:60
 msgid "Moderation Lists"
-msgstr "Listas de Moderación"
+msgstr "Listaxes de Moderación"
 
 #: src/components/moderation/LabelPreference.tsx:246
 msgid "moderation settings"
@@ -4133,7 +3817,9 @@ msgstr "Ferramentas de moderación"
 #: src/components/moderation/ModerationDetailsDialog.tsx:51
 #: src/lib/moderation/useModerationCauseDescription.ts:45
 msgid "Moderator has chosen to set a general warning on the content."
-msgstr "O moderador escolleu definir un aviso xeral para o contido."
+msgstr ""
+"A persoas moderadora decidiu establecer unha advertencia xeral sobre o "
+"contido. "
 
 #: src/view/com/post-thread/PostThreadItem.tsx:619
 msgid "More"
@@ -4141,7 +3827,7 @@ msgstr "Máis"
 
 #: src/view/shell/desktop/Feeds.tsx:55
 msgid "More feeds"
-msgstr "Máis fontes"
+msgstr "Máis canles"
 
 #: src/view/com/profile/ProfileMenu.tsx:179
 #: src/view/screens/ProfileList.tsx:712
@@ -4150,7 +3836,7 @@ msgstr "Máis opcións"
 
 #: src/view/screens/PreferencesThreads.tsx:77
 msgid "Most-liked replies first"
-msgstr ""
+msgstr "Primeiro as respostas con máis gústame"
 
 #: src/screens/Onboarding/state.ts:92
 msgid "Movies"
@@ -4164,12 +3850,6 @@ msgstr "Música"
 msgid "Mute"
 msgstr "Silenciar"
 
-#: src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerNative.tsx:157
-#: src/view/com/util/post-embeds/VideoEmbedInner/web-controls/VolumeControl.tsx:94
-msgctxt "video"
-msgid "Mute"
-msgstr "Silenciar"
-
 #: src/components/TagMenu/index.web.tsx:116
 msgid "Mute {truncatedTag}"
 msgstr "Silenciar {truncatedTag}"
@@ -4177,7 +3857,7 @@ msgstr "Silenciar {truncatedTag}"
 #: src/view/com/profile/ProfileMenu.tsx:259
 #: src/view/com/profile/ProfileMenu.tsx:266
 msgid "Mute Account"
-msgstr "Silenciar Conta"
+msgstr "Silenciar conta"
 
 #: src/view/screens/ProfileList.tsx:631
 msgid "Mute accounts"
@@ -4185,20 +3865,12 @@ msgstr "Silenciar contas"
 
 #: src/components/TagMenu/index.tsx:205
 msgid "Mute all {displayTag} posts"
-msgstr "Silenciar todas as publicacións {displayTag}"
+msgstr "Silenciar todos os chíos con {displayTag}"
 
 #: src/components/dms/ConvoMenu.tsx:172
 #: src/components/dms/ConvoMenu.tsx:178
 msgid "Mute conversation"
 msgstr "Silenciar conversa"
-
-#: src/components/dialogs/MutedWords.tsx:148
-#~ msgid "Mute in tags only"
-#~ msgstr "Silenciar só nas etiquetas"
-
-#: src/components/dialogs/MutedWords.tsx:133
-#~ msgid "Mute in text & tags"
-#~ msgstr "Silenciar no texto e etiquetas"
 
 #: src/components/dialogs/MutedWords.tsx:253
 msgid "Mute in:"
@@ -4206,12 +3878,7 @@ msgstr "Silenciar en:"
 
 #: src/view/screens/ProfileList.tsx:737
 msgid "Mute list"
-msgstr "Silenciar lista"
-
-#: src/components/dms/ConvoMenu.tsx:136
-#: src/components/dms/ConvoMenu.tsx:142
-#~ msgid "Mute notifications"
-#~ msgstr "Silenciar notificacións"
+msgstr "Silenciar a listaxe"
 
 #: src/view/screens/ProfileList.tsx:732
 msgid "Mute these accounts?"
@@ -4219,19 +3886,19 @@ msgstr "Silenciar estas contas?"
 
 #: src/components/dialogs/MutedWords.tsx:185
 msgid "Mute this word for 24 hours"
-msgstr "Silenciar esta palabra durante 24 horas"
+msgstr "Silenciar esta palabra por 24 horas"
 
 #: src/components/dialogs/MutedWords.tsx:224
 msgid "Mute this word for 30 days"
-msgstr "Silenciar esta palabra durante 30 días"
+msgstr "Silenciar esta palabra por 30 días"
 
 #: src/components/dialogs/MutedWords.tsx:209
 msgid "Mute this word for 7 days"
-msgstr "Silenciar esta palabra durante 7 días"
+msgstr "Silenciar esta palabra por 7 días"
 
 #: src/components/dialogs/MutedWords.tsx:258
 msgid "Mute this word in post text and tags"
-msgstr "Silenciar esta palabra no texto e etiquetas da publicación"
+msgstr "Silenciar esta palabra no texto do chío e as etiquetas"
 
 #: src/components/dialogs/MutedWords.tsx:274
 msgid "Mute this word in tags only"
@@ -4239,7 +3906,7 @@ msgstr "Silenciar esta palabra só nas etiquetas"
 
 #: src/components/dialogs/MutedWords.tsx:170
 msgid "Mute this word until you unmute it"
-msgstr ""
+msgstr "Silenciar esta palabra ata que a actives"
 
 #: src/view/com/util/forms/PostDropdownBtn.tsx:507
 #: src/view/com/util/forms/PostDropdownBtn.tsx:513
@@ -4251,10 +3918,6 @@ msgstr "Silenciar fío"
 msgid "Mute words & tags"
 msgstr "Silenciar palabras e etiquetas"
 
-#: src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerNative.tsx:168
-#~ msgid "Muted"
-#~ msgstr "Silenciado"
-
 #: src/screens/Moderation/index.tsx:265
 msgid "Muted accounts"
 msgstr "Contas silenciadas"
@@ -4265,8 +3928,12 @@ msgid "Muted Accounts"
 msgstr "Contas Silenciadas"
 
 #: src/view/screens/ModerationMutedAccounts.tsx:116
-msgid "Muted accounts have their posts removed from your feed and from your notifications. Mutes are completely private."
-msgstr "Non verás as publicacións das contas silenciadas na túa fonte e nas notificacións. Silenciar é privado."
+msgid ""
+"Muted accounts have their posts removed from your feed and from your "
+"notifications. Mutes are completely private."
+msgstr ""
+"As publicacións das contas silenciadas elimínanse das túas canles e das "
+"túas notificacións. As contas silenciadas son completamente privadas."
 
 #: src/lib/moderation/useModerationCauseDescription.ts:90
 msgid "Muted by \"{0}\""
@@ -4277,29 +3944,33 @@ msgid "Muted words & tags"
 msgstr "Palabras e etiquetas silenciadas"
 
 #: src/view/screens/ProfileList.tsx:734
-msgid "Muting is private. Muted accounts can interact with you, but you will not see their posts or receive notifications from them."
-msgstr "Silenciar é privado. As contas silenciadas poden interacturar contigo, mais non verás as súas publicacións ou recibir notificacións delas."
+msgid ""
+"Muting is private. Muted accounts can interact with you, but you will not "
+"see their posts or receive notifications from them."
+msgstr ""
+"Ninguén pode ver a quen silencias. As contas silenciadas poden interactuar "
+"contigo, máis non verás os seus chíos nin recibirás notificacións deles."
 
 #: src/components/dialogs/BirthDateSettings.tsx:34
 #: src/components/dialogs/BirthDateSettings.tsx:37
 msgid "My Birthday"
-msgstr "O meu Aniversario"
+msgstr "O meu aniversario"
 
 #: src/view/screens/Feeds.tsx:732
 msgid "My Feeds"
-msgstr "As miñas Fontes"
+msgstr "As miñas canles"
 
 #: src/view/shell/desktop/LeftNav.tsx:85
 msgid "My Profile"
-msgstr "O meu Perfil"
+msgstr "O meu perfil"
 
 #: src/view/screens/Settings/index.tsx:583
 msgid "My saved feeds"
-msgstr "As miñas fontes gardadas"
+msgstr "As miñas canles gardadas"
 
 #: src/view/screens/Settings/index.tsx:589
 msgid "My Saved Feeds"
-msgstr "As miñas Fontes Gardadas"
+msgstr "As Miñas Canles Gardadas"
 
 #: src/view/com/modals/AddAppPasswords.tsx:174
 #: src/view/com/modals/CreateOrEditList.tsx:270
@@ -4308,14 +3979,14 @@ msgstr "Nome"
 
 #: src/view/com/modals/CreateOrEditList.tsx:135
 msgid "Name is required"
-msgstr "O nome é requirido"
+msgstr "Nome requerido"
 
 #: src/lib/moderation/useReportOptions.ts:59
 #: src/lib/moderation/useReportOptions.ts:98
 #: src/lib/moderation/useReportOptions.ts:106
 #: src/lib/moderation/useReportOptions.ts:114
 msgid "Name or Description Violates Community Standards"
-msgstr "O nome ou a descrición violan os estándares da comunidade"
+msgstr "O nome ou a descrición está a violar as normas da comunidade "
 
 #: src/screens/Onboarding/index.tsx:22
 #: src/screens/Onboarding/state.ts:94
@@ -4324,56 +3995,47 @@ msgstr "Natureza"
 
 #: src/components/StarterPack/StarterPackCard.tsx:124
 msgid "Navigate to {0}"
-msgstr "Ir a {0}"
-
-#: src/view/com/util/post-embeds/ExternalLinkEmbed.tsx:86
-#~ msgid "Navigate to starter pack"
-#~ msgstr "Ir ao paquete de inicio"
+msgstr "Navegar a {0}"
 
 #: src/screens/Login/ForgotPasswordForm.tsx:166
 #: src/screens/Login/LoginForm.tsx:316
 #: src/view/com/modals/ChangePassword.tsx:169
 msgid "Navigates to the next screen"
-msgstr "Ir á seguinte pantalla"
+msgstr "Navega á seguinte pantalla"
 
 #: src/view/shell/Drawer.tsx:72
 msgid "Navigates to your profile"
-msgstr "Ir ao teu perfil"
+msgstr "Navega ao teu perfil"
 
 #: src/components/dialogs/VerifyEmailDialog.tsx:156
 msgid "Need to change it?"
-msgstr "É preciso mudar isto?"
+msgstr "Necesitas cambialo?"
 
 #: src/components/ReportDialog/SelectReportOptionView.tsx:130
 msgid "Need to report a copyright violation?"
-msgstr "Precisas denunciar unha violación de copyright?"
+msgstr "Necesitas reportar unha violación de copyright?"
 
 #: src/screens/Onboarding/StepFinished.tsx:255
 msgid "Never lose access to your followers or data."
-msgstr "Non perdas nunca o acceso aos teus seguidores ou datos."
+msgstr "Nunca perdas o acceso aos teus seguidores nin ao teus datos."
 
 #: src/view/com/modals/ChangeHandle.tsx:508
 msgid "Nevermind, create a handle for me"
-msgstr "Tanto ten, crea un nome de usuario para min"
-
-#: src/view/screens/Lists.tsx:84
-msgctxt "action"
-msgid "New"
-msgstr "Nova"
+msgstr "Non importa, crea un alcume para min"
 
 #: src/view/screens/ModerationModlists.tsx:80
 msgid "New"
-msgstr "Nova"
+msgstr "Non"
 
 #: src/components/dms/dialogs/NewChatDialog.tsx:54
 #: src/screens/Messages/ChatList.tsx:328
 #: src/screens/Messages/ChatList.tsx:335
 msgid "New chat"
-msgstr "Nova conversa"
+msgstr "Novo chat"
 
 #: src/components/dialogs/nuxs/NeueTypography.tsx:51
 msgid "New font settings ✨"
-msgstr "Novos axustes de fonte ✨"
+msgstr "Novos axustes de fontes ✨"
 
 #: src/components/dms/NewMessagesPill.tsx:92
 msgid "New messages"
@@ -4381,20 +4043,15 @@ msgstr "Novas mensaxes"
 
 #: src/view/com/modals/CreateOrEditList.tsx:232
 msgid "New Moderation List"
-msgstr "Nova lista de moderación"
+msgstr "Nova listaxe de moderación"
 
 #: src/view/com/modals/ChangePassword.tsx:213
 msgid "New password"
-msgstr "Contrasinal novo"
+msgstr "Novo contrasinal"
 
 #: src/view/com/modals/ChangePassword.tsx:218
 msgid "New Password"
-msgstr "Contrasinal Novo"
-
-#: src/view/com/feeds/FeedPage.tsx:143
-msgctxt "action"
-msgid "New post"
-msgstr "Nova publicación"
+msgstr "Novo Contrasinal"
 
 #: src/view/screens/Feeds.tsx:582
 #: src/view/screens/Notifications.tsx:224
@@ -4404,29 +4061,24 @@ msgstr "Nova publicación"
 #: src/view/screens/ProfileList.tsx:287
 #: src/view/shell/desktop/LeftNav.tsx:303
 msgid "New post"
-msgstr "Nova publicación"
-
-#: src/view/shell/desktop/LeftNav.tsx:311
-msgctxt "action"
-msgid "New Post"
-msgstr "Nova Publicación"
+msgstr "Novo chío"
 
 #: src/components/NewskieDialog.tsx:83
 msgid "New user info dialog"
-msgstr ""
+msgstr "Nova xanela de información desta persoa"
 
 #: src/view/com/modals/CreateOrEditList.tsx:227
 msgid "New User List"
-msgstr ""
+msgstr "Nova listaxe de persoas"
 
 #: src/view/screens/PreferencesThreads.tsx:74
 msgid "Newest replies first"
-msgstr ""
+msgstr "Primeiro as respostas máis recentes"
 
 #: src/screens/Onboarding/index.tsx:20
 #: src/screens/Onboarding/state.ts:95
 msgid "News"
-msgstr "Novas"
+msgstr "Noticias"
 
 #: src/screens/Login/ForgotPasswordForm.tsx:137
 #: src/screens/Login/ForgotPasswordForm.tsx:143
@@ -4442,11 +4094,11 @@ msgstr "Novas"
 #: src/view/com/modals/ChangePassword.tsx:254
 #: src/view/com/modals/ChangePassword.tsx:256
 msgid "Next"
-msgstr "Seguinte"
+msgstr "Siguinte"
 
 #: src/view/com/lightbox/Lightbox.web.tsx:169
 msgid "Next image"
-msgstr "Seguinte imaxe"
+msgstr "Nova imaxe"
 
 #: src/view/screens/PreferencesFollowingFeed.tsx:71
 #: src/view/screens/PreferencesFollowingFeed.tsx:97
@@ -4464,62 +4116,62 @@ msgstr "Sen descrición"
 
 #: src/view/com/modals/ChangeHandle.tsx:392
 msgid "No DNS Panel"
-msgstr ""
+msgstr "Sen panel de DNS"
 
 #: src/components/dialogs/GifSelect.tsx:230
 msgid "No featured GIFs found. There may be an issue with Tenor."
-msgstr ""
+msgstr "Non se atoparon GIF destacados. Pode haber un problema con Tenor."
 
 #: src/screens/StarterPack/Wizard/StepFeeds.tsx:118
 msgid "No feeds found. Try searching for something else."
-msgstr ""
+msgstr "Non se encontraron canles. Intenta buscar algo máis."
 
 #: src/components/LikedByList.tsx:78
 #: src/view/com/post-thread/PostLikedBy.tsx:85
 msgid "No likes yet"
-msgstr ""
+msgstr "Aínda sen gústames"
 
 #: src/components/ProfileCard.tsx:338
 #: src/screens/Profile/Header/ProfileHeaderStandard.tsx:109
 msgid "No longer following {0}"
-msgstr ""
+msgstr "Xa non segues a {0}"
 
 #: src/screens/Signup/StepHandle.tsx:169
 msgid "No longer than 253 characters"
-msgstr ""
+msgstr "Non máis de 253 caracteres"
 
 #: src/screens/Messages/components/ChatListItem.tsx:116
 msgid "No messages yet"
-msgstr ""
+msgstr "Aínda non hai mensaxes"
 
 #: src/screens/Messages/ChatList.tsx:271
 msgid "No more conversations to show"
-msgstr ""
+msgstr "Non hai máis conversas que mostrar"
 
 #: src/view/com/notifications/Feed.tsx:121
 msgid "No notifications yet!"
-msgstr ""
+msgstr "Aínda non hai notificacións!"
 
 #: src/screens/Messages/Settings.tsx:95
 #: src/screens/Messages/Settings.tsx:98
 msgid "No one"
-msgstr ""
+msgstr "Ninguén"
 
 #: src/components/WhoCanReply.tsx:237
 msgid "No one but the author can quote this post."
-msgstr ""
+msgstr "Ninguén, excepto a persoa autora, pode citar este chío."
 
 #: src/screens/Profile/Sections/Feed.tsx:65
 msgid "No posts yet."
-msgstr ""
+msgstr "Aínda non hai chíos."
 
 #: src/view/com/post-thread/PostQuotes.tsx:106
 msgid "No quotes yet"
-msgstr ""
+msgstr "Aínda non hai citas."
 
 #: src/view/com/post-thread/PostRepostedBy.tsx:78
 msgid "No reposts yet"
-msgstr ""
+msgstr "Aínda non hai rechouchíos"
 
 #: src/view/com/composer/text-input/mobile/Autocomplete.tsx:111
 #: src/view/com/composer/text-input/web/Autocomplete.tsx:196
@@ -4532,26 +4184,22 @@ msgstr "Sen resultados"
 
 #: src/components/Lists.tsx:215
 msgid "No results found"
-msgstr "Sen resultados"
+msgstr "Non se encontraron resultados"
 
 #: src/view/screens/Feeds.tsx:513
 msgid "No results found for \"{query}\""
-msgstr "Sen resultados para \"{query}\""
+msgstr "Non se encontraron resultados para \"{query}\""
 
 #: src/view/com/modals/ListAddRemoveUsers.tsx:128
 #: src/view/screens/Search/Search.tsx:239
 #: src/view/screens/Search/Search.tsx:278
 #: src/view/screens/Search/Search.tsx:324
 msgid "No results found for {query}"
-msgstr "Sen resultados para {query}"
+msgstr "Non se encontraron resultados para {query}"
 
 #: src/components/dialogs/GifSelect.tsx:228
 msgid "No search results found for \"{search}\"."
-msgstr "Sen resultados para \"{search}\"."
-
-#: src/components/dms/NewChat.tsx:240
-#~ msgid "No search results found for \"{searchText}\"."
-#~ msgstr "Sen resultados para \"{searchText}\"."
+msgstr "Non se encontraron resultados de búsqueda para \"{search}\"."
 
 #: src/components/dialogs/EmbedConsent.tsx:104
 #: src/components/dialogs/EmbedConsent.tsx:111
@@ -4562,45 +4210,37 @@ msgstr "Non, grazas"
 msgid "Nobody"
 msgstr "Ninguén"
 
-#: src/view/com/composer/threadgate/ThreadgateBtn.tsx:46
-#~ msgid "Nobody can reply"
-#~ msgstr "Ninguén pode responder"
-
 #: src/components/LikedByList.tsx:80
 #: src/components/LikesDialog.tsx:97
 #: src/view/com/post-thread/PostLikedBy.tsx:87
 msgid "Nobody has liked this yet. Maybe you should be the first!"
-msgstr ""
+msgstr "A ninguén lle gustou isto. Ao mellor deberías darlle unha oportunidade!"
 
 #: src/view/com/post-thread/PostQuotes.tsx:108
 msgid "Nobody has quoted this yet. Maybe you should be the first!"
-msgstr ""
+msgstr "Ninguén citou isto. Poderías levar a dianteira e citalo antes que ninguén! "
 
 #: src/view/com/post-thread/PostRepostedBy.tsx:80
 msgid "Nobody has reposted this yet. Maybe you should be the first!"
-msgstr ""
+msgstr "Ninguén volveu publicar isto. Deberías volvelo a publicar!"
 
 #: src/screens/StarterPack/Wizard/StepProfiles.tsx:102
 msgid "Nobody was found. Try searching for someone else."
-msgstr ""
+msgstr "Non se encontrou a ninguén. Proba a buscar a outra persoa."
 
 #: src/lib/moderation/useGlobalLabelStrings.ts:42
 msgid "Non-sexual Nudity"
 msgstr "Nudez non sexual"
 
-#: src/view/com/modals/SelfLabel.tsx:135
-#~ msgid "Not Applicable."
-#~ msgstr "Non aplicábel."
-
 #: src/Navigation.tsx:124
 #: src/view/screens/Profile.tsx:128
 msgid "Not Found"
-msgstr "Non atopado"
+msgstr "Non se encontrou"
 
 #: src/view/com/modals/VerifyEmail.tsx:254
 #: src/view/com/modals/VerifyEmail.tsx:260
 msgid "Not right now"
-msgstr "Agora non"
+msgstr "Non neste momento"
 
 #: src/view/com/profile/ProfileMenu.tsx:348
 #: src/view/com/util/forms/PostDropdownBtn.tsx:698
@@ -4609,12 +4249,21 @@ msgid "Note about sharing"
 msgstr "Nota sobre compartir"
 
 #: src/screens/Moderation/index.tsx:578
-msgid "Note: Bluesky is an open and public network. This setting only limits the visibility of your content on the Bluesky app and website, and other apps may not respect this setting. Your content may still be shown to logged-out users by other apps and websites."
-msgstr "Nota: Bluesky é unha rede pública e aberta. Este axuste só limita a visibilidade do teu contido na aplicación e web do Bluesky, mais é posíbel que otruas aplicacións non respecten este axuste. Outras aplicacións e sitios web poderán amosar o teu contido a usuarios desconectados."
+msgid ""
+"Note: Bluesky is an open and public network. This setting only limits the "
+"visibility of your content on the Bluesky app and website, and other apps "
+"may not respect this setting. Your content may still be shown to logged-out "
+"users by other apps and websites."
+msgstr ""
+"Nota: Bluesky é unha rede aberta e pública. Esta configuración só limita a "
+"visibilidade do teu contido na aplicación e no sitio web de Bluesky, e é "
+"posíbel que outras aplicacións non respecten esta configuración. O teu "
+"contido aínda se pode mostrar ás persoas que pecharon sesión por outras "
+"aplicacións e sitios web."
 
 #: src/screens/Messages/ChatList.tsx:213
 msgid "Nothing here"
-msgstr "Nada aquí"
+msgstr "Non hai nada aquí"
 
 #: src/view/screens/NotificationsSettings.tsx:57
 msgid "Notification filters"
@@ -4623,19 +4272,19 @@ msgstr "Filtros de notificacións"
 #: src/Navigation.tsx:347
 #: src/view/screens/Notifications.tsx:117
 msgid "Notification settings"
-msgstr "Axustes das notificacións"
+msgstr "Axustes de notificacións"
 
 #: src/view/screens/NotificationsSettings.tsx:42
 msgid "Notification Settings"
-msgstr "Axustes das Notificacións"
+msgstr "Axustes de notificacións"
 
 #: src/screens/Messages/Settings.tsx:117
 msgid "Notification sounds"
-msgstr "Sons das notificacións"
+msgstr "Sons de notificacións"
 
 #: src/screens/Messages/Settings.tsx:114
 msgid "Notification Sounds"
-msgstr "Sons das Notificacións"
+msgstr "Sons de Notificacións"
 
 #: src/Navigation.tsx:559
 #: src/view/screens/Notifications.tsx:143
@@ -4662,11 +4311,7 @@ msgstr "Nudez"
 
 #: src/lib/moderation/useReportOptions.ts:78
 msgid "Nudity or adult content not labeled as such"
-msgstr "Nudez ou contido para adultos non etiquetado coma tal"
-
-#: src/screens/Signup/index.tsx:145
-#~ msgid "of"
-#~ msgstr "de"
+msgstr "Desnudez ou contido para persoas adultas non etiquetado como tal"
 
 #: src/lib/moderation/useLabelBehaviorDescription.ts:11
 msgid "Off"
@@ -4675,35 +4320,23 @@ msgstr "Apagar"
 #: src/components/dialogs/GifSelect.tsx:269
 #: src/view/com/util/ErrorBoundary.tsx:57
 msgid "Oh no!"
-msgstr "Vaites!"
+msgstr "Ai, non!"
 
 #: src/screens/Onboarding/StepInterests/index.tsx:124
 msgid "Oh no! Something went wrong."
-msgstr "Vaites! Algo foi mal."
-
-#: src/components/dialogs/nuxs/TenMillion/index.tsx:175
-#~ msgid "Oh no! We weren't able to generate an image for you to share. Rest assured, we're glad you're here 🦋"
-#~ msgstr "Madía leva! Non puidemos xerar unha imaxe para que a compartas. Acouga, estamos ledos de que esteas aquí 🦋"
+msgstr "Vaites! Algo non furrula ben."
 
 #: src/screens/Profile/Header/ProfileHeaderLabeler.tsx:337
 msgid "OK"
-msgstr "Aceptar"
+msgstr "Ben"
 
 #: src/screens/Login/PasswordUpdatedForm.tsx:38
 msgid "Okay"
-msgstr "Aceptar"
+msgstr "Está ben"
 
 #: src/view/screens/PreferencesThreads.tsx:73
 msgid "Oldest replies first"
-msgstr "Primeiro as respostas antigas"
-
-#: src/components/StarterPack/QrCode.tsx:69
-#~ msgid "on"
-#~ msgstr "en"
-
-#: src/lib/hooks/useTimeAgo.ts:81
-#~ msgid "on {str}"
-#~ msgstr "en {str}"
+msgstr "Primeiro as respostas máis antigas"
 
 #: src/components/StarterPack/QrCode.tsx:75
 msgid "on<0><1/><2><3/></2></0>"
@@ -4711,23 +4344,15 @@ msgstr "en<0><1/><2><3/></2></0>"
 
 #: src/view/screens/Settings/index.tsx:227
 msgid "Onboarding reset"
-msgstr "Restablecer benvida"
-
-#: src/tours/Tooltip.tsx:118
-#~ msgid "Onboarding tour step {0}: {1}"
-#~ msgstr "Paso {0} do percorrido de benvida: {1}"
+msgstr "Restablecemento da incorporación"
 
 #: src/view/com/composer/Composer.tsx:739
 msgid "One or more images is missing alt text."
-msgstr "Unha ou máis imaxes non teñen texto alternativo."
+msgstr "Falta o texto alternativo nunha ou máis imaxes."
 
 #: src/screens/Onboarding/StepProfile/index.tsx:115
 msgid "Only .jpg and .png files are supported"
-msgstr "Só os ficheiros .jpg e .png están soportados"
-
-#: src/components/WhoCanReply.tsx:245
-#~ msgid "Only {0} can reply"
-#~ msgstr "Só {0} pode responder"
+msgstr "Só se admiten ficheiros .jpg e .png"
 
 #: src/components/WhoCanReply.tsx:217
 msgid "Only {0} can reply."
@@ -4735,19 +4360,19 @@ msgstr "Só {0} pode responder."
 
 #: src/screens/Signup/StepHandle.tsx:152
 msgid "Only contains letters, numbers, and hyphens"
-msgstr "Só contén letras, números, e guións"
+msgstr "Só contén letras, números e guións"
 
 #: src/lib/media/picker.shared.ts:29
 msgid "Only image files are supported"
-msgstr "Só os ficheiros de imaxe están soportados"
+msgstr "Só se admiten ficheiros de imaxe"
 
 #: src/view/com/composer/videos/SubtitleFilePicker.tsx:40
 msgid "Only WebVTT (.vtt) files are supported"
-msgstr "Só os ficheiros WebVTT (.vtt) están soportados"
+msgstr "Só se admiten ficheiros WebVTT (.vtt)."
 
 #: src/components/Lists.tsx:88
 msgid "Oops, something went wrong!"
-msgstr "Vaites, algo foi mal!"
+msgstr "Vaites, algo non furrula ben!"
 
 #: src/components/Lists.tsx:199
 #: src/components/StarterPack/ProfileStarterPacks.tsx:305
@@ -4760,30 +4385,30 @@ msgstr "Vaites!"
 
 #: src/screens/Onboarding/StepFinished.tsx:251
 msgid "Open"
-msgstr "Abrir"
+msgstr "Aberto"
 
 #: src/view/com/posts/AviFollowButton.tsx:86
 msgid "Open {name} profile shortcut menu"
-msgstr ""
+msgstr "Abre o menú de acceso directo do perfil {name}"
 
 #: src/screens/Onboarding/StepProfile/index.tsx:286
 msgid "Open avatar creator"
-msgstr ""
+msgstr "Abrir o creador de avatares"
 
 #: src/screens/Messages/components/ChatListItem.tsx:272
 #: src/screens/Messages/components/ChatListItem.tsx:273
 msgid "Open conversation options"
-msgstr ""
+msgstr "Abrir as opcións de conversa"
 
 #: src/screens/Messages/components/MessageInput.web.tsx:165
 #: src/view/com/composer/Composer.tsx:999
 #: src/view/com/composer/Composer.tsx:1000
 msgid "Open emoji picker"
-msgstr ""
+msgstr "Abrir o selector de emoji"
 
 #: src/view/screens/ProfileFeed.tsx:301
 msgid "Open feed options menu"
-msgstr ""
+msgstr "Abre o menú de opcións das canles"
 
 #: src/view/com/util/post-embeds/ExternalLinkEmbed.tsx:71
 msgid "Open link to {niceUrl}"
@@ -4791,15 +4416,15 @@ msgstr "Abrir ligazón a {niceUrl}"
 
 #: src/view/screens/Settings/index.tsx:703
 msgid "Open links with in-app browser"
-msgstr "Abrir ligazóns co navegador na app"
+msgstr "Abrir as ligazóns co navegador na aplicación"
 
 #: src/components/dms/ActionsWrapper.tsx:87
 msgid "Open message options"
-msgstr "Abrir opcións da mensaxe"
+msgstr "Abrir opcións de mensaxe"
 
 #: src/screens/Moderation/index.tsx:231
 msgid "Open muted words and tags settings"
-msgstr "Abrir axustes de palabras e etiquetas silenciadas"
+msgstr "Abrir os axustes de palabras e etiquetas silenciadas"
 
 #: src/view/com/home/HomeHeaderLayoutMobile.tsx:54
 msgid "Open navigation"
@@ -4807,182 +4432,171 @@ msgstr "Abrir navegación"
 
 #: src/view/com/util/forms/PostDropdownBtn.tsx:365
 msgid "Open post options menu"
-msgstr "Abrir menú de opcións da publicación"
+msgstr "Abrir menú de opciones do chío"
 
 #: src/screens/StarterPack/StarterPackScreen.tsx:551
 msgid "Open starter pack menu"
-msgstr "Abrir o menú do paquete de inicio"
+msgstr "Abrir menú do paquete de inicio"
 
 #: src/view/screens/Settings/index.tsx:827
 #: src/view/screens/Settings/index.tsx:837
 msgid "Open storybook page"
-msgstr ""
+msgstr "Abrir pagina de histórico"
 
 #: src/view/screens/Settings/index.tsx:815
 msgid "Open system log"
-msgstr "Abrir rexistro de sistema"
+msgstr "Abrir registro do sistema."
 
 #: src/view/com/util/forms/DropdownButton.tsx:159
 msgid "Opens {numItems} options"
-msgstr "Abre {munItems} opcións"
+msgstr "Abre {numItems} opciones."
 
 #: src/view/com/composer/labels/LabelsBtn.tsx:63
 msgid "Opens a dialog to add a content warning to your post"
-msgstr "Abre un diálogo para engadir un aviso de contido para a túa publicación"
+msgstr "Abre unha xanela para engadir unha advertencia de contido á túa publicación"
 
 #: src/view/com/composer/threadgate/ThreadgateBtn.tsx:62
 msgid "Opens a dialog to choose who can reply to this thread"
-msgstr "Abre un diálogo para escoller quen pode responder a este fío"
+msgstr "Abre unha xanela para elegir quién puede responder a este hilo."
 
 #: src/view/screens/Settings/index.tsx:456
 msgid "Opens accessibility settings"
-msgstr "Abre os axustes de accesibilidade"
+msgstr "Abrir axustes de accesibilidad"
 
 #: src/view/screens/Log.tsx:59
 msgid "Opens additional details for a debug entry"
-msgstr "Abre os detalles adicionais para unha entrada de depuración."
-
-#: src/view/com/notifications/FeedItem.tsx:349
-#~ msgid "Opens an expanded list of users in this notification"
-#~ msgstr "Abre unha lista expandida de usuarios nesta notificación"
+msgstr "Abre detalles adicionales para una entrada de depuración."
 
 #: src/view/screens/Settings/index.tsx:477
 msgid "Opens appearance settings"
-msgstr "Abre os axustes de aparencia"
+msgstr "Abrir axustes de apariencia"
 
 #: src/view/com/composer/photos/OpenCameraBtn.tsx:73
 msgid "Opens camera on device"
-msgstr "Abre a cámara do dispositivo"
+msgstr "Abrir cámara do dispositivo"
 
 #: src/view/screens/Settings/index.tsx:606
 msgid "Opens chat settings"
-msgstr "Abre os axustes de conversa"
+msgstr "Abrir axustes de chat"
 
 #: src/view/com/post-thread/PostThreadComposePrompt.tsx:36
 msgid "Opens composer"
-msgstr "Abre o editor"
+msgstr "Abrir compositor"
 
 #: src/view/screens/Settings/index.tsx:498
 msgid "Opens configurable language settings"
-msgstr "Abre os axustes da lingua configurábel"
+msgstr "Abrir a configuración do idioma que se puede ajustar"
 
 #: src/view/com/composer/photos/SelectPhotoBtn.tsx:51
 msgid "Opens device photo gallery"
-msgstr "Abre a galería de fotos do dispositivo"
+msgstr "Abrir galería de fotos do dispositivo"
 
 #: src/view/screens/Settings/index.tsx:638
 msgid "Opens external embeds settings"
-msgstr ""
+msgstr "Abrir a configuración de insercións externas"
 
 #: src/view/com/auth/SplashScreen.tsx:50
 #: src/view/com/auth/SplashScreen.web.tsx:110
 msgid "Opens flow to create a new Bluesky account"
-msgstr ""
+msgstr "Abrir o fluxo para crear unha nova conta Bluesky"
 
 #: src/view/com/auth/SplashScreen.tsx:64
 #: src/view/com/auth/SplashScreen.web.tsx:124
 msgid "Opens flow to sign into your existing Bluesky account"
-msgstr ""
+msgstr "Abrir o fluxo para iniciar sesión na túa conta Bluesky existente"
 
 #: src/view/com/composer/photos/SelectGifBtn.tsx:36
 msgid "Opens GIF select dialog"
-msgstr "Abre o diálogo de selección de GIFs"
+msgstr "Abrir a xanela de selección de GIF"
 
 #: src/view/com/modals/InviteCodes.tsx:173
 msgid "Opens list of invite codes"
-msgstr "Abre a lista de códigos de convite"
+msgstr "Abrir a listaxe de códigos de convite"
 
 #: src/view/screens/Settings/index.tsx:775
 msgid "Opens modal for account deactivation confirmation"
-msgstr "Abre a modal pra confirmar a desactivación da conta"
+msgstr "Abrir o modal para a confirmación da desactivación da conta"
 
 #: src/view/screens/Settings/index.tsx:797
 msgid "Opens modal for account deletion confirmation. Requires email code"
-msgstr "Abre a modal para confirmar a eliminación da conta. Requírese o código enviado ao correo"
+msgstr ""
+"Abrir o modal para a confirmación da eliminación da conta. Require código "
+"de correo electrónico"
 
 #: src/view/screens/Settings/index.tsx:732
 msgid "Opens modal for changing your Bluesky password"
-msgstr "Abre a modal para mudar o teu contrasinal do Bluesky"
+msgstr "Abrir o modal para cambiar o teu contrasinal de Bluesky"
 
 #: src/view/screens/Settings/index.tsx:687
 msgid "Opens modal for choosing a new Bluesky handle"
-msgstr "Abre a modal para escoller un novo nome de usuario no Bluesky"
+msgstr "Abrir modal para escoller un novo controlador Bluesky"
 
 #: src/view/screens/Settings/index.tsx:755
 msgid "Opens modal for downloading your Bluesky account data (repository)"
-msgstr "Abre a modal para descargar os datos da túa conta no Bluesky (repositorio)"
+msgstr "Abrir o modal para descargar os datos da túa conta Bluesky (repositorio)"
 
 #: src/view/screens/Settings/index.tsx:963
 msgid "Opens modal for email verification"
-msgstr "Abre a modal para a verificación do correo"
+msgstr "Abrir o modal para a verificación do correo electrónico"
 
 #: src/view/com/modals/ChangeHandle.tsx:269
 msgid "Opens modal for using custom domain"
-msgstr "Abre a modal para usar o dominio personalizado"
+msgstr "Abrir o modal para usar o dominio personalizado"
 
 #: src/view/screens/Settings/index.tsx:523
 msgid "Opens moderation settings"
-msgstr "Abre os axustes de moderación"
+msgstr "Abrir a configuración de moderación"
 
 #: src/screens/Login/LoginForm.tsx:231
 msgid "Opens password reset form"
-msgstr "Abre o formulario para restablecer o contrasinal"
-
-#: src/view/com/home/HomeHeaderLayout.web.tsx:77
-#: src/view/screens/Feeds.tsx:417
-#~ msgid "Opens screen to edit Saved Feeds"
-#~ msgstr "Abre a pantalla para editar as fontes gardadas"
+msgstr "Abrir o formulario de restablecemento do contrasinal"
 
 #: src/view/screens/Settings/index.tsx:584
 msgid "Opens screen with all saved feeds"
-msgstr "Abre a pantalla con todas as fontes gardadas"
+msgstr "Abrir a pantalla con todas as canles guardadas"
 
 #: src/view/screens/Settings/index.tsx:665
 msgid "Opens the app password settings"
-msgstr "Abre os axustes de contrasinal"
+msgstr "Abrir a configuración do contrasinal da aplicación"
 
 #: src/view/screens/Settings/index.tsx:541
 msgid "Opens the Following feed preferences"
-msgstr ""
+msgstr "Abrir as seguintes preferencias das canles"
 
 #: src/view/com/modals/LinkWarning.tsx:93
 msgid "Opens the linked website"
-msgstr "Abre o sitio web vinculado"
-
-#: src/screens/Messages/List/index.tsx:86
-#~ msgid "Opens the message settings page"
-#~ msgstr "Abre a páxina de axustes da mensaxe"
+msgstr "Abrir o sitio web ligado"
 
 #: src/view/screens/Settings/index.tsx:828
 #: src/view/screens/Settings/index.tsx:838
 msgid "Opens the storybook page"
-msgstr ""
+msgstr "Abrir a páxina do libro dos contos"
 
 #: src/view/screens/Settings/index.tsx:816
 msgid "Opens the system log page"
-msgstr "Abre o rexistro do sistema"
+msgstr "Abrir a páxina de rexistro do sistema"
 
 #: src/view/screens/Settings/index.tsx:562
 msgid "Opens the threads preferences"
-msgstr "Abre as preferencias de fíos"
+msgstr "Abrir as preferencias dos fíos"
 
 #: src/view/com/notifications/FeedItem.tsx:555
 #: src/view/com/util/UserAvatar.tsx:436
 msgid "Opens this profile"
-msgstr "Abre este perfil"
+msgstr "Abrir este perfil"
 
 #: src/view/com/composer/videos/SelectVideoBtn.tsx:107
 msgid "Opens video picker"
-msgstr "Abre o selector de vídeo"
+msgstr "Abrir o selector de vídeos"
 
 #: src/view/com/util/forms/DropdownButton.tsx:293
 msgid "Option {0} of {numItems}"
-msgstr "Opción {0} de {numItems}"
+msgstr "Opcion {0} de {numItems}"
 
 #: src/components/dms/ReportDialog.tsx:178
 #: src/components/ReportDialog/SubmitView.tsx:167
 msgid "Optionally provide additional information below:"
-msgstr "De xeito opcional fornece información adicional abaixo:"
+msgstr "Opcionalmente, proporcione información adicional a continuación:"
 
 #: src/components/dialogs/MutedWords.tsx:299
 msgid "Options:"
@@ -4994,16 +4608,16 @@ msgstr "Ou combina estas opcións:"
 
 #: src/screens/Deactivated.tsx:211
 msgid "Or, continue with another account."
-msgstr "Ou, continua con outra conta."
+msgstr "Ou, continúa con outra conta."
 
 #: src/screens/Deactivated.tsx:194
 msgid "Or, log into one of your other accounts."
-msgstr "Ou, inicia sesión con outras das túas contas."
+msgstr "Ou, inicia sesión cunha das outras contas."
 
 #: src/lib/moderation/useReportOptions.ts:27
 #: src/view/com/composer/labels/LabelsBtn.tsx:183
 msgid "Other"
-msgstr "Outra"
+msgstr "Outro"
 
 #: src/components/AccountList.tsx:83
 msgid "Other account"
@@ -5015,20 +4629,24 @@ msgstr "Outras contas"
 
 #: src/view/com/composer/select-language/SelectLangBtn.tsx:92
 msgid "Other..."
-msgstr "Outra..."
+msgstr "Outro..."
 
 #: src/screens/Messages/components/ChatDisabled.tsx:28
-msgid "Our moderators have reviewed reports and decided to disable your access to chats on Bluesky."
-msgstr "Os nosos moderadores despois de revisar varios informes, decidiron deshabilitar ao teu acceso as conversas no Bluesky."
+msgid ""
+"Our moderators have reviewed reports and decided to disable your access to "
+"chats on Bluesky."
+msgstr ""
+"Os nosos moderadores revisaron os informes e decidiron desactivar o teu "
+"acceso ás conversas en Bluesky."
 
 #: src/components/Lists.tsx:216
 #: src/view/screens/NotFound.tsx:47
 msgid "Page not found"
-msgstr "Páxina non atopada"
+msgstr "Non se atopou a páxina"
 
 #: src/view/screens/NotFound.tsx:44
 msgid "Page Not Found"
-msgstr "Páxina Non Atopada"
+msgstr "Non se atopou a páxina"
 
 #: src/screens/Login/LoginForm.tsx:210
 #: src/screens/Signup/StepInfo/index.tsx:192
@@ -5039,7 +4657,7 @@ msgstr "Contrasinal"
 
 #: src/view/com/modals/ChangePassword.tsx:143
 msgid "Password Changed"
-msgstr "Contrasinal mudado"
+msgstr "Cambiou o contrasinal"
 
 #: src/screens/Login/index.tsx:154
 msgid "Password updated"
@@ -5053,36 +4671,40 @@ msgstr "Contrasinal actualizado!"
 #: src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerNative.tsx:141
 #: src/view/com/util/post-embeds/VideoEmbedInner/web-controls/VideoControls.tsx:371
 msgid "Pause"
-msgstr "Por en pausa"
+msgstr "Pausar"
 
 #: src/view/com/util/post-embeds/VideoEmbedInner/web-controls/VideoControls.tsx:323
 msgid "Pause video"
-msgstr "Por en pausa o vídeo"
+msgstr "Pausar vídeo"
 
 #: src/screens/StarterPack/StarterPackScreen.tsx:182
 #: src/view/screens/Search/Search.tsx:531
 msgid "People"
-msgstr "Xente"
+msgstr "Persoas"
 
 #: src/Navigation.tsx:179
 msgid "People followed by @{0}"
-msgstr "Xente seguida por @{0}"
+msgstr "Persoas seguidas por @{0}"
 
 #: src/Navigation.tsx:172
 msgid "People following @{0}"
-msgstr "Xente seguindo a @{0}"
+msgstr "Persoas siguindo a @{0}"
 
 #: src/view/com/lightbox/Lightbox.tsx:77
 msgid "Permission to access camera roll is required."
-msgstr "Requírese permisos para acceder á galería."
+msgstr "Requírese permiso para acceder ao carrete da cámara."
 
 #: src/view/com/lightbox/Lightbox.tsx:85
-msgid "Permission to access camera roll was denied. Please enable it in your system settings."
-msgstr "Os permisos para acceder á galería foron denegados. Por favor, habilitaos nos axustes do sistema."
+msgid ""
+"Permission to access camera roll was denied. Please enable it in your "
+"system settings."
+msgstr ""
+"O permiso para acceder ao carrete da cámara foi denegado. Por favor, "
+"actívao na configuración do teu sistema."
 
 #: src/components/StarterPack/Wizard/WizardListCard.tsx:55
 msgid "Person toggle"
-msgstr "Alternar persoa"
+msgstr "Alternancia de persoa"
 
 #: src/screens/Onboarding/index.tsx:28
 #: src/screens/Onboarding/state.ts:96
@@ -5095,7 +4717,7 @@ msgstr "Fotografía"
 
 #: src/view/com/composer/labels/LabelsBtn.tsx:168
 msgid "Pictures meant for adults."
-msgstr "Imaxes destinadas a adultos."
+msgstr "Imaxes pensadas para persoas adultas."
 
 #: src/view/screens/ProfileFeed.tsx:293
 #: src/view/screens/ProfileList.tsx:676
@@ -5109,7 +4731,7 @@ msgstr "Fixar no Inicio"
 #: src/view/com/util/forms/PostDropdownBtn.tsx:398
 #: src/view/com/util/forms/PostDropdownBtn.tsx:405
 msgid "Pin to your profile"
-msgstr "Fixar ao teu perfil"
+msgstr "Fixar no teu perfil"
 
 #: src/view/com/posts/FeedItem.tsx:354
 msgid "Pinned"
@@ -5117,11 +4739,11 @@ msgstr "Fixado"
 
 #: src/view/screens/SavedFeeds.tsx:130
 msgid "Pinned Feeds"
-msgstr "Fontes fixadas"
+msgstr "Canles fixadas"
 
 #: src/view/screens/ProfileList.tsx:355
 msgid "Pinned to your feeds"
-msgstr "Fixado ás túas fontes"
+msgstr "As túas canles fixadas"
 
 #: src/view/com/util/post-embeds/GifEmbed.tsx:43
 #: src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerNative.tsx:141
@@ -5133,91 +4755,92 @@ msgstr "Reproducir"
 msgid "Play {0}"
 msgstr "Reproducir {0}"
 
-#: src/screens/Messages/Settings.tsx:97
-#: src/screens/Messages/Settings.tsx:104
-#~ msgid "Play notification sounds"
-#~ msgstr "Reproducir sons de notificacións"
-
 #: src/view/com/util/post-embeds/GifEmbed.tsx:42
 msgid "Play or pause the GIF"
-msgstr "Reproducir ou por en pausa o GIF"
+msgstr "Reproducir ou pausar GIF"
 
 #: src/view/com/util/post-embeds/VideoEmbed.tsx:110
 #: src/view/com/util/post-embeds/VideoEmbedInner/web-controls/VideoControls.tsx:324
 msgid "Play video"
-msgstr "Reproducir o vídeo"
+msgstr "Reproducir vídeo"
 
 #: src/view/com/util/post-embeds/ExternalPlayerEmbed.tsx:58
 #: src/view/com/util/post-embeds/ExternalPlayerEmbed.tsx:59
 msgid "Play Video"
-msgstr "Reproducir o vídeo"
+msgstr "Reproducir Vídeo"
 
 #: src/view/com/util/post-embeds/ExternalGifEmbed.tsx:127
 msgid "Plays the GIF"
-msgstr "Reproducir o GIF"
+msgstr "Reproducir GIF"
 
 #: src/screens/Signup/state.ts:217
 msgid "Please choose your handle."
-msgstr "Por favor, escolle o teu nome de usuario."
+msgstr "Por favor, escolle o teu alcume."
 
 #: src/screens/Signup/state.ts:210
 #: src/screens/Signup/StepInfo/index.tsx:114
 msgid "Please choose your password."
-msgstr ""
+msgstr "Por favor, escolle o teu contrasinal."
 
 #: src/screens/Signup/state.ts:231
 msgid "Please complete the verification captcha."
-msgstr "Por favor, completa a captcha de verificación."
+msgstr "Por favor, completa a verificación CAPTCHA"
 
 #: src/view/com/modals/ChangeEmail.tsx:65
-msgid "Please confirm your email before changing it. This is a temporary requirement while email-updating tools are added, and it will soon be removed."
+msgid ""
+"Please confirm your email before changing it. This is a temporary "
+"requirement while email-updating tools are added, and it will soon be "
+"removed."
 msgstr ""
+"Confirma o teu correo electrónico antes de cambialo. Este é un requisito "
+"temporal mentres se engaden ferramentas de actualización de correo "
+"electrónico e en breve eliminarase."
 
 #: src/view/com/modals/AddAppPasswords.tsx:94
 msgid "Please enter a name for your app password. All spaces is not allowed."
-msgstr "Por favor, insire un nome para o teu contrasinal. Os espazos non están permitidos."
+msgstr "Introduce un nome para o contrasinal da aplicación. Non se permiten espazos."
 
 #: src/view/com/modals/AddAppPasswords.tsx:151
-msgid "Please enter a unique name for this App Password or use our randomly generated one."
-msgstr "Por favor, insire un nome único para este contrasinal ou emprega un xerado ao chou."
+msgid ""
+"Please enter a unique name for this App Password or use our randomly "
+"generated one."
+msgstr ""
+"Introduce un nome único para este contrasinal da aplicación ou utiliza o "
+"noso xerado aleatoriamente."
 
 #: src/components/dialogs/MutedWords.tsx:86
 msgid "Please enter a valid word, tag, or phrase to mute"
-msgstr "Por favor, insire unha palabra, etiqueta ou frase para silenciar válida"
+msgstr "Introduce unha palabra, etiqueta ou frase válida para silenciar"
 
 #: src/screens/Signup/state.ts:196
 #: src/screens/Signup/StepInfo/index.tsx:102
 msgid "Please enter your email."
-msgstr "Por favor, insire o teu correo."
+msgstr "Introduce o teu correo electrónico."
 
 #: src/screens/Signup/StepInfo/index.tsx:96
 msgid "Please enter your invite code."
-msgstr "Por favor, insire o teu código de convite."
+msgstr "Introduce o teu código de convite."
 
 #: src/view/com/modals/DeleteAccount.tsx:253
 msgid "Please enter your password as well:"
-msgstr "Por favor, insire tamén o teu contrasinal:"
+msgstr "Introduce tamén o teu contrasinal:"
 
 #: src/components/moderation/LabelsOnMeDialog.tsx:265
 msgid "Please explain why you think this label was incorrectly applied by {0}"
-msgstr "Por favor, explica por que cres que esta etiqueta foi aplicada de xeito incorrecto por {0}"
+msgstr "Explica por que cres que esta etiqueta foi aplicada incorrectamente por {0}"
 
 #: src/screens/Messages/components/ChatDisabled.tsx:110
 msgid "Please explain why you think your chats were incorrectly disabled"
-msgstr "Por favor, explica por que cres que as túas conversas foron deshabilitadas de xeito incorrecto"
+msgstr "Explica por que cres que se desactivaron incorrectamente as túas conversas"
 
 #: src/lib/hooks/useAccountSwitcher.ts:45
 #: src/lib/hooks/useAccountSwitcher.ts:55
 msgid "Please sign in as @{0}"
-msgstr "Por favor, inicia sesión como @{0}"
+msgstr "Inicia sesión como @{0}"
 
 #: src/view/com/modals/VerifyEmail.tsx:109
 msgid "Please Verify Your Email"
-msgstr "Por favor, verifica o teu correo"
-
-#: src/view/com/composer/Composer.tsx:359
-#~ msgid "Please wait for your link card to finish loading"
-#~ msgstr "Por favor, agarda a que o teu cartón de ligado remate de cargar"
+msgstr "Verifica o teu enderezo electrónico"
 
 #: src/screens/Onboarding/index.tsx:34
 #: src/screens/Onboarding/state.ts:98
@@ -5229,99 +4852,92 @@ msgstr "Política"
 msgid "Porn"
 msgstr "Pornografía"
 
-#: src/view/com/composer/Composer.tsx:710
-#: src/view/com/composer/Composer.tsx:717
-msgctxt "action"
-msgid "Post"
-msgstr "Publicar"
-
-#: src/view/com/post-thread/PostThread.tsx:481
-msgctxt "description"
-msgid "Post"
-msgstr "Publicación"
-
 #: src/view/com/post-thread/PostThreadItem.tsx:196
 msgid "Post by {0}"
-msgstr "Publicado por {0}"
+msgstr "Chío de {0}"
 
 #: src/Navigation.tsx:198
 #: src/Navigation.tsx:205
 #: src/Navigation.tsx:212
 #: src/Navigation.tsx:219
 msgid "Post by @{0}"
-msgstr "Publicado por @{0}"
+msgstr "Chío de @{0}"
 
 #: src/view/com/util/forms/PostDropdownBtn.tsx:180
 msgid "Post deleted"
-msgstr "Publicación eliminada"
+msgstr "Chío eliminado"
 
 #: src/lib/api/index.ts:161
 msgid "Post failed to upload. Please check your Internet connection and try again."
-msgstr "Produciuse un erro ao enviar a publicación. Por favor, verifica a túa conexión a internet e téntao de novo."
+msgstr ""
+"Produciuse un erro ao cargar o chío. Comproba a túa conexión a Internet e "
+"téntao de novo."
 
 #: src/view/com/post-thread/PostThread.tsx:212
 msgid "Post hidden"
-msgstr "Publicación oculta"
+msgstr "Chío oculto"
 
 #: src/components/moderation/ModerationDetailsDialog.tsx:106
 #: src/lib/moderation/useModerationCauseDescription.ts:104
 msgid "Post Hidden by Muted Word"
-msgstr "Publicación oculta por unha palabra silenciada"
+msgstr "Chío oculto por palabra silenciada"
 
 #: src/components/moderation/ModerationDetailsDialog.tsx:109
 #: src/lib/moderation/useModerationCauseDescription.ts:113
 msgid "Post Hidden by You"
-msgstr "Publicación oculta por ti"
+msgstr "Chío ocultado por ti"
 
 #: src/components/dialogs/PostInteractionSettingsDialog.tsx:284
 msgid "Post interaction settings"
-msgstr "Axustes de interacción de publicación"
+msgstr "Axustes de interacción do chío"
 
 #: src/view/com/composer/select-language/SelectLangBtn.tsx:88
 msgid "Post language"
-msgstr "Lingua da publicación"
+msgstr "Idioma do chío"
 
 #: src/view/com/modals/lang-settings/PostLanguagesSettings.tsx:76
 msgid "Post Languages"
-msgstr "Linguas da publicación"
+msgstr "Idiomas dos chíos"
 
 #: src/view/com/post-thread/PostThread.tsx:207
 #: src/view/com/post-thread/PostThread.tsx:219
 msgid "Post not found"
-msgstr "Publicación non atopada"
+msgstr "Non se encontrou o chío"
 
 #: src/state/queries/pinned-post.ts:59
 msgid "Post pinned"
-msgstr "Publicación fixada"
+msgstr "Chío fixado"
 
 #: src/state/queries/pinned-post.ts:61
 msgid "Post unpinned"
-msgstr "Publicación desfixada"
+msgstr "Chío desfixado"
 
 #: src/components/TagMenu/index.tsx:252
 msgid "posts"
-msgstr "publicacións"
+msgstr "chíos"
 
 #: src/screens/StarterPack/StarterPackScreen.tsx:184
 #: src/view/screens/Profile.tsx:228
 msgid "Posts"
-msgstr "Publicacións"
-
-#: src/components/dialogs/MutedWords.tsx:89
-#~ msgid "Posts can be muted based on their text, their tags, or both."
-#~ msgstr "As publicacións pódense silenciar segundo o seu texto, etiquetas ou ambos."
+msgstr "Chíos"
 
 #: src/components/dialogs/MutedWords.tsx:115
-msgid "Posts can be muted based on their text, their tags, or both. We recommend avoiding common words that appear in many posts, since it can result in no posts being shown."
-msgstr "As publicacións pódense silenciar segundo o seu texto, etiquetas ou ambos. Recomendamos evitar palabras comúns que aparezan en moitas publicacións, xa que podería facer que non se vexa ningunha publicación."
+msgid ""
+"Posts can be muted based on their text, their tags, or both. We recommend "
+"avoiding common words that appear in many posts, since it can result in no "
+"posts being shown."
+msgstr ""
+"Os chíos pódense silenciar en función do seu texto, das súas etiquetas ou "
+"de ambos. Recomendamos evitar as palabras comúns que aparecen en moitos "
+"chíos, xa que pode provocar que non se mostre ningún chío."
 
 #: src/view/com/posts/FeedErrorMessage.tsx:68
 msgid "Posts hidden"
-msgstr "Publicacións ocultas"
+msgstr "Chíos ocultos"
 
 #: src/view/com/modals/LinkWarning.tsx:60
 msgid "Potentially Misleading Link"
-msgstr ""
+msgstr "Ligazón potencialmente enganosa"
 
 #: src/state/queries/notifications/settings.ts:44
 msgid "Preference saved"
@@ -5329,27 +4945,22 @@ msgstr "Preferencias gardadas"
 
 #: src/screens/Messages/components/MessageListError.tsx:19
 msgid "Press to attempt reconnection"
-msgstr "Premer para tentar conectar de novo"
+msgstr "Preme para tentar a conexión"
 
 #: src/components/forms/HostingProvider.tsx:46
 msgid "Press to change hosting provider"
-msgstr "Premer para mudar o provedor de hospedaxe"
+msgstr "Preme para cambiar o fornecedor de hosting"
 
 #: src/components/Error.tsx:61
 #: src/components/Lists.tsx:93
 #: src/screens/Messages/components/MessageListError.tsx:24
 #: src/screens/Signup/BackNextButtons.tsx:48
 msgid "Press to retry"
-msgstr "Premer para tentar de novo"
-
-#: src/screens/Messages/Conversation/MessagesList.tsx:47
-#: src/screens/Messages/Conversation/MessagesList.tsx:53
-#~ msgid "Press to Retry"
-#~ msgstr "Premer para tentar de novo"
+msgstr "Preme para reintentar"
 
 #: src/components/KnownFollowers.tsx:124
 msgid "Press to view followers of this account that you also follow"
-msgstr "Premer para ver os seguidores desta conta que tamén segues"
+msgstr "Preme para ver as persoas desta conta que tamén segues"
 
 #: src/view/com/lightbox/Lightbox.web.tsx:150
 msgid "Previous image"
@@ -5357,11 +4968,11 @@ msgstr "Imaxe previa"
 
 #: src/view/screens/LanguageSettings.tsx:188
 msgid "Primary Language"
-msgstr "Lingua principal"
+msgstr "Idioma primario"
 
 #: src/view/screens/PreferencesThreads.tsx:92
 msgid "Prioritize Your Follows"
-msgstr "Priorizar os usuarios aos que segues"
+msgstr "Priorizar as persoas ás que segues"
 
 #: src/view/screens/NotificationsSettings.tsx:60
 msgid "Priority notifications"
@@ -5378,11 +4989,7 @@ msgstr "Privacidade"
 #: src/view/shell/Drawer.tsx:291
 #: src/view/shell/Drawer.tsx:292
 msgid "Privacy Policy"
-msgstr "Política de Privacidade"
-
-#: src/components/dms/MessagesNUX.tsx:91
-#~ msgid "Privately chat with other users."
-#~ msgstr "Conversa privada con outros usuarios."
+msgstr "Política de privacidade"
 
 #: src/view/com/composer/Composer.tsx:1347
 msgid "Processing video..."
@@ -5411,7 +5018,7 @@ msgstr "Perfil actualizado"
 
 #: src/view/screens/Settings/index.tsx:976
 msgid "Protect your account by verifying your email."
-msgstr "Protexe a túa conta verificando o teu correo."
+msgstr "Protexa a súa conta verificando o seu correo electrónico."
 
 #: src/screens/Onboarding/StepFinished.tsx:237
 msgid "Public"
@@ -5420,59 +5027,39 @@ msgstr "Público"
 #: src/view/screens/ModerationModlists.tsx:63
 msgid "Public, shareable lists of users to mute or block in bulk."
 msgstr ""
+"Listaxes públicas e compartíbeis de persoas para silenciar ou bloquear en "
+"masa."
 
 #: src/view/screens/Lists.tsx:69
 msgid "Public, shareable lists which can drive feeds."
-msgstr ""
-
-#: src/view/com/composer/Composer.tsx:579
-#~ msgid "Publish post"
-#~ msgstr "Publicar publicación"
-
-#: src/view/com/composer/Composer.tsx:579
-#~ msgid "Publish reply"
-#~ msgstr "Publicar resposta"
+msgstr "Listaxes públicas e compartíbeis que poden xerar canles."
 
 #: src/components/StarterPack/QrCodeDialog.tsx:128
 msgid "QR code copied to your clipboard!"
-msgstr "Código QR copiado ao portapapeis!"
+msgstr "O código QR copiouse no portapapeis!"
 
 #: src/components/StarterPack/QrCodeDialog.tsx:106
 msgid "QR code has been downloaded!"
-msgstr "Código QR descargado!"
+msgstr "O código QR foi descargado!"
 
 #: src/components/StarterPack/QrCodeDialog.tsx:107
 msgid "QR code saved to your camera roll!"
-msgstr "Código QR gardado na túa galería!"
-
-#: src/tours/Tooltip.tsx:111
-#~ msgid "Quick tip"
-#~ msgstr "Suxestión rápida"
+msgstr "O código QR gardouse no carrete da cámara."
 
 #: src/view/com/util/post-ctrls/RepostButton.tsx:129
 #: src/view/com/util/post-ctrls/RepostButton.tsx:156
 #: src/view/com/util/post-ctrls/RepostButton.web.tsx:85
 #: src/view/com/util/post-ctrls/RepostButton.web.tsx:92
 msgid "Quote post"
-msgstr "Citar publicación"
-
-#: src/view/com/modals/Repost.tsx:66
-#~ msgctxt "action"
-#~ msgid "Quote post"
-#~ msgstr "Citar publicación"
-
-#: src/view/com/modals/Repost.tsx:71
-#~ msgctxt "action"
-#~ msgid "Quote Post"
-#~ msgstr "Citar publicación"
+msgstr "Citar un chío"
 
 #: src/view/com/util/forms/PostDropdownBtn.tsx:308
 msgid "Quote post was re-attached"
-msgstr "A publicación citada foi reanexada"
+msgstr "O chío citado foi anexado de novo"
 
 #: src/view/com/util/forms/PostDropdownBtn.tsx:307
 msgid "Quote post was successfully detached"
-msgstr "A publicación citada foi desanexada"
+msgstr "O chío citado separouse correctamente"
 
 #: src/components/dialogs/PostInteractionSettingsDialog.tsx:314
 #: src/view/com/util/post-ctrls/RepostButton.tsx:128
@@ -5488,7 +5075,7 @@ msgstr "Citas habilitadas"
 
 #: src/components/dialogs/PostInteractionSettingsDialog.tsx:296
 msgid "Quote settings"
-msgstr "Axustes de citas"
+msgstr "Configuración de citas"
 
 #: src/screens/Post/PostQuotes.tsx:32
 #: src/screens/Post/PostQuotes.tsx:33
@@ -5497,54 +5084,46 @@ msgstr "Citas"
 
 #: src/view/com/post-thread/PostThreadItem.tsx:230
 msgid "Quotes of this post"
-msgstr "Citas desta publicación"
+msgstr "Citas deste chío"
 
 #: src/view/screens/PreferencesThreads.tsx:81
 msgid "Random (aka \"Poster's Roulette\")"
-msgstr ""
-
-#: src/view/com/modals/EditImage.tsx:237
-#~ msgid "Ratios"
-#~ msgstr "Proporcións"
+msgstr "Aleatorio (aka \"Poster's Roulette\")"
 
 #: src/view/com/util/forms/PostDropdownBtn.tsx:585
 #: src/view/com/util/forms/PostDropdownBtn.tsx:595
 msgid "Re-attach quote"
-msgstr "Reanexar cita"
+msgstr "Volver a anexar cita"
 
 #: src/screens/Deactivated.tsx:144
 msgid "Reactivate your account"
-msgstr "Volver activar a túa conta"
+msgstr "Reactiva a túa conta"
 
 #: src/view/com/auth/SplashScreen.web.tsx:170
 msgid "Read the Bluesky blog"
-msgstr "Ler o blog do Bluesky"
+msgstr "Le o blog de Bluesky"
 
 #: src/screens/Signup/StepInfo/Policies.tsx:58
 #: src/screens/Signup/StepInfo/Policies.tsx:84
 msgid "Read the Bluesky Privacy Policy"
-msgstr "Ler a Política de Privacidade do Bluesky"
+msgstr "Le a Política de privacidade de Bluesky"
 
 #: src/screens/Signup/StepInfo/Policies.tsx:51
 #: src/screens/Signup/StepInfo/Policies.tsx:71
 msgid "Read the Bluesky Terms of Service"
-msgstr "Ler os Termos de Servizo do Bluesky"
+msgstr "Le as Condicións de servizo de Bluesky"
 
 #: src/components/dms/ReportDialog.tsx:169
 msgid "Reason:"
-msgstr "Motivo:"
-
-#: src/components/dms/MessageReportDialog.tsx:149
-#~ msgid "Reason: {0}"
-#~ msgstr "Motivo: {0}"
+msgstr "Razón:"
 
 #: src/view/screens/Search/Search.tsx:1056
 msgid "Recent Searches"
-msgstr "Procuras recentes"
+msgstr "Busquedas Recentes"
 
 #: src/screens/Messages/components/MessageListError.tsx:20
 msgid "Reconnect"
-msgstr "Volver conectar"
+msgstr "Reconectar"
 
 #: src/view/screens/Notifications.tsx:144
 msgid "Refresh notifications"
@@ -5552,7 +5131,7 @@ msgstr "Actualizar notificacións"
 
 #: src/screens/Messages/ChatList.tsx:198
 msgid "Reload conversations"
-msgstr "Cargar de novo as conversas"
+msgstr "Recargar as conversas"
 
 #: src/components/dialogs/MutedWords.tsx:438
 #: src/components/FeedCard.tsx:316
@@ -5568,11 +5147,11 @@ msgstr "Eliminar"
 
 #: src/components/StarterPack/Wizard/WizardListCard.tsx:58
 msgid "Remove {displayName} from starter pack"
-msgstr "Eliminar {displayName} do paquete de inicio"
+msgstr "Eliminar a {displayName} do paquete inicial"
 
 #: src/view/com/util/AccountDropdownBtn.tsx:26
 msgid "Remove account"
-msgstr "Eliminar conta"
+msgstr "Eliminar a conta"
 
 #: src/view/com/composer/ExternalEmbedRemoveBtn.tsx:16
 msgid "Remove attachment"
@@ -5584,21 +5163,21 @@ msgstr "Eliminar Avatar"
 
 #: src/view/com/util/UserBanner.tsx:155
 msgid "Remove Banner"
-msgstr "Eliminar Cartaz"
+msgstr "Eliminar Banner"
 
 #: src/screens/Messages/components/MessageInputEmbed.tsx:206
 msgid "Remove embed"
-msgstr "Eliminar incrustado"
+msgstr "Eliminar incrustación"
 
 #: src/view/com/posts/FeedErrorMessage.tsx:169
 #: src/view/com/posts/FeedShutdownMsg.tsx:116
 #: src/view/com/posts/FeedShutdownMsg.tsx:120
 msgid "Remove feed"
-msgstr "Eliminar fonte"
+msgstr "Eliminar canle"
 
 #: src/view/com/posts/FeedErrorMessage.tsx:210
 msgid "Remove feed?"
-msgstr "Eliminar fonte?"
+msgstr "Eliminar canle?"
 
 #: src/view/com/feeds/FeedSourceCard.tsx:187
 #: src/view/com/feeds/FeedSourceCard.tsx:265
@@ -5607,32 +5186,28 @@ msgstr "Eliminar fonte?"
 #: src/view/screens/ProfileList.tsx:502
 #: src/view/screens/SavedFeeds.tsx:351
 msgid "Remove from my feeds"
-msgstr "Eliminar das miñas fontes"
+msgstr "Eliminar das miñas canles"
 
 #: src/components/FeedCard.tsx:311
 #: src/view/com/feeds/FeedSourceCard.tsx:311
 msgid "Remove from my feeds?"
-msgstr "Eliminar das miñas fontes?"
+msgstr "Eliminar das miñas canles?"
 
 #: src/view/com/util/AccountDropdownBtn.tsx:53
 msgid "Remove from quick access?"
-msgstr "Eliminar do acceso rápido?"
+msgstr "Eliminar o acceso rápido?"
 
 #: src/screens/List/ListHiddenScreen.tsx:156
 msgid "Remove from saved feeds"
-msgstr "Eliminar das fontes gardadas"
+msgstr "Eliminar das canles gardadas"
 
 #: src/view/com/composer/photos/Gallery.tsx:200
 msgid "Remove image"
-msgstr "Eliminar imaxe"
-
-#: src/view/com/composer/ExternalEmbedRemoveBtn.tsx:28
-#~ msgid "Remove image preview"
-#~ msgstr "Eliminar a vista previa da imaxe"
+msgstr "Eliminar a imaxe"
 
 #: src/components/dialogs/MutedWords.tsx:523
 msgid "Remove mute word from your list"
-msgstr "Eliminar a palabra silenciada da túa lista"
+msgstr "Elimina a palabra silenciada da túa listaxe"
 
 #: src/view/screens/Search/Search.tsx:1100
 msgid "Remove profile"
@@ -5640,7 +5215,7 @@ msgstr "Eliminar perfil"
 
 #: src/view/screens/Search/Search.tsx:1102
 msgid "Remove profile from search history"
-msgstr "Eliminar perfil do historial de procuras"
+msgstr "Eliminar o perfil do historial de busca"
 
 #: src/view/com/util/post-embeds/QuoteEmbed.tsx:273
 msgid "Remove quote"
@@ -5649,19 +5224,19 @@ msgstr "Eliminar cita"
 #: src/view/com/util/post-ctrls/RepostButton.tsx:102
 #: src/view/com/util/post-ctrls/RepostButton.tsx:118
 msgid "Remove repost"
-msgstr "Eliminar publicación"
+msgstr "Eliminar rechouchío"
 
 #: src/view/com/composer/videos/SubtitleDialog.tsx:260
 msgid "Remove subtitle file"
-msgstr "Eliminar ficheiro de subtítulos"
+msgstr "Eliminar o ficheiro de lexendas"
 
 #: src/view/com/posts/FeedErrorMessage.tsx:211
 msgid "Remove this feed from your saved feeds"
-msgstr "Eliminar esta fonte das túas fontes gardadas"
+msgstr "Eliminar esta canle das túas canles gardadas"
 
 #: src/view/com/util/post-embeds/QuoteEmbed.tsx:108
 msgid "Removed by author"
-msgstr "Eliminado polo autor/a"
+msgstr "Eliminado pola persoa autora"
 
 #: src/view/com/util/post-embeds/QuoteEmbed.tsx:106
 msgid "Removed by you"
@@ -5670,43 +5245,31 @@ msgstr "Eliminado por ti"
 #: src/view/com/modals/ListAddRemoveUsers.tsx:200
 #: src/view/com/modals/UserAddRemoveLists.tsx:170
 msgid "Removed from list"
-msgstr "Eliminado da lista"
+msgstr "Eliminado da listaxe"
 
 #: src/view/com/feeds/FeedSourceCard.tsx:138
 msgid "Removed from my feeds"
-msgstr "Eliminada das miñas fontes"
+msgstr "Eliminado das miñas canles"
 
 #: src/screens/List/ListHiddenScreen.tsx:94
 #: src/screens/List/ListHiddenScreen.tsx:160
 msgid "Removed from saved feeds"
-msgstr "Eliminada das fontes gardadas"
+msgstr "Eliminado das miñas canles gardadas"
 
 #: src/view/com/posts/FeedShutdownMsg.tsx:44
 #: src/view/screens/ProfileFeed.tsx:197
 #: src/view/screens/ProfileList.tsx:386
 msgid "Removed from your feeds"
-msgstr "Eliminada das túas fontes"
-
-#: src/view/com/composer/ExternalEmbed.tsx:88
-#~ msgid "Removes default thumbnail from {0}"
-#~ msgstr ""
+msgstr "Eliminado das miñas canles"
 
 #: src/view/com/util/post-embeds/QuoteEmbed.tsx:274
 msgid "Removes quoted post"
-msgstr "Elimina a publicación citada"
-
-#: src/view/com/composer/ExternalEmbedRemoveBtn.tsx:29
-#~ msgid "Removes the attachment"
-#~ msgstr "Elimina o anexo"
-
-#: src/view/com/composer/ExternalEmbedRemoveBtn.tsx:29
-#~ msgid "Removes the image preview"
-#~ msgstr "Elimina a vista previa da imaxe"
+msgstr "Eliminar o chío citado"
 
 #: src/view/com/posts/FeedShutdownMsg.tsx:129
 #: src/view/com/posts/FeedShutdownMsg.tsx:133
 msgid "Replace with Discover"
-msgstr "Substituír con Descubrir"
+msgstr "Substitúeo por Discover"
 
 #: src/view/screens/Profile.tsx:229
 msgid "Replies"
@@ -5716,31 +5279,14 @@ msgstr "Respostas"
 msgid "Replies disabled"
 msgstr "Respostas deshabilitadas"
 
-#: src/view/com/threadgate/WhoCanReply.tsx:123
-#~ msgid "Replies on this thread are disabled"
-#~ msgstr "As respostas neste fío están deshabilitadas"
-
 #: src/components/WhoCanReply.tsx:215
 msgid "Replies to this post are disabled."
-msgstr "As respostas a esta publicación están deshabilitadas."
-
-#: src/components/WhoCanReply.tsx:243
-#~ msgid "Replies to this thread are disabled"
-#~ msgstr "As respostas a este fío están deshabilitadas"
-
-#: src/view/com/composer/Composer.tsx:708
-msgctxt "action"
-msgid "Reply"
-msgstr "Responder"
-
-#: src/view/screens/PreferencesFollowingFeed.tsx:142
-#~ msgid "Reply Filters"
-#~ msgstr "Filtros de respostas"
+msgstr "As respostas a este chío están desactivadas."
 
 #: src/components/moderation/ModerationDetailsDialog.tsx:115
 #: src/lib/moderation/useModerationCauseDescription.ts:123
 msgid "Reply Hidden by Thread Author"
-msgstr "Resposta ocultada polo autor do fío"
+msgstr "Resposta oculta pola persoa autora do fío"
 
 #: src/components/moderation/ModerationDetailsDialog.tsx:114
 #: src/lib/moderation/useModerationCauseDescription.ts:122
@@ -5753,37 +5299,15 @@ msgstr "Axustes de resposta"
 
 #: src/components/dialogs/PostInteractionSettingsDialog.tsx:341
 msgid "Reply settings are chosen by the author of the thread"
-msgstr "Os axustes de resposta son escollidos polo autor do fío"
-
-#: src/view/com/post/Post.tsx:195
-#: src/view/com/posts/FeedItem.tsx:544
-msgctxt "description"
-msgid "Reply to <0><1/></0>"
-msgstr "Responder a <0><1/></0>"
-
-#: src/view/com/posts/FeedItem.tsx:535
-msgctxt "description"
-msgid "Reply to a blocked post"
-msgstr "Responder a unha publicación bloqueada"
-
-#: src/view/com/posts/FeedItem.tsx:537
-msgctxt "description"
-msgid "Reply to a post"
-msgstr "Responder a unha publicación"
-
-#: src/view/com/post/Post.tsx:193
-#: src/view/com/posts/FeedItem.tsx:541
-msgctxt "description"
-msgid "Reply to you"
-msgstr "Responder a ti"
+msgstr "A configuración de resposta é elixida pola persoa autora do fío"
 
 #: src/view/com/util/forms/PostDropdownBtn.tsx:338
 msgid "Reply visibility updated"
-msgstr ""
+msgstr "Visibilidade da resposta actualizada"
 
 #: src/view/com/util/forms/PostDropdownBtn.tsx:337
 msgid "Reply was successfully hidden"
-msgstr ""
+msgstr "A resposta ocultouse correctamente."
 
 #: src/components/dms/MessageMenu.tsx:132
 #: src/components/dms/MessagesListBlockedFooter.tsx:77
@@ -5791,34 +5315,29 @@ msgstr ""
 msgid "Report"
 msgstr "Denunciar"
 
-#: src/components/dms/ConvoMenu.tsx:146
-#: src/components/dms/ConvoMenu.tsx:150
-#~ msgid "Report account"
-#~ msgstr "Denunciar unha conta"
-
 #: src/view/com/profile/ProfileMenu.tsx:299
 #: src/view/com/profile/ProfileMenu.tsx:302
 msgid "Report Account"
-msgstr "Denunciar unha conta"
+msgstr "Denunciar conta"
 
 #: src/components/dms/ConvoMenu.tsx:197
 #: src/components/dms/ConvoMenu.tsx:200
 #: src/components/dms/ReportConversationPrompt.tsx:18
 msgid "Report conversation"
-msgstr "Denunciar unha conversa"
+msgstr "Denunciar conversación"
 
 #: src/components/ReportDialog/index.tsx:44
 msgid "Report dialog"
-msgstr "Diálogo de denuncia"
+msgstr "Xanela da denuncia"
 
 #: src/view/screens/ProfileFeed.tsx:354
 #: src/view/screens/ProfileFeed.tsx:356
 msgid "Report feed"
-msgstr "Denunciar fonte"
+msgstr "Denunciar canle"
 
 #: src/view/screens/ProfileList.tsx:544
 msgid "Report List"
-msgstr "Denunciar lista"
+msgstr "Denunciar listaxe"
 
 #: src/components/dms/MessageMenu.tsx:130
 msgid "Report message"
@@ -5827,7 +5346,7 @@ msgstr "Denunciar mensaxe"
 #: src/view/com/util/forms/PostDropdownBtn.tsx:621
 #: src/view/com/util/forms/PostDropdownBtn.tsx:623
 msgid "Report post"
-msgstr "Denunciar publicación"
+msgstr "Denunciar chío"
 
 #: src/screens/StarterPack/StarterPackScreen.tsx:604
 #: src/screens/StarterPack/StarterPackScreen.tsx:607
@@ -5840,11 +5359,11 @@ msgstr "Denunciar este contido"
 
 #: src/components/ReportDialog/SelectReportOptionView.tsx:56
 msgid "Report this feed"
-msgstr "Denunciar esta fonte"
+msgstr "Denunciar esta canle"
 
 #: src/components/ReportDialog/SelectReportOptionView.tsx:53
 msgid "Report this list"
-msgstr "Denunciar esta lista"
+msgstr "Denunciar esta listaxe"
 
 #: src/components/dms/ReportDialog.tsx:44
 #: src/components/dms/ReportDialog.tsx:137
@@ -5854,7 +5373,7 @@ msgstr "Denunciar esta mensaxe"
 
 #: src/components/ReportDialog/SelectReportOptionView.tsx:50
 msgid "Report this post"
-msgstr "Denunciar esta publicación"
+msgstr "Denunciar este chío"
 
 #: src/components/ReportDialog/SelectReportOptionView.tsx:59
 msgid "Report this starter pack"
@@ -5862,132 +5381,125 @@ msgstr "Denunciar este paquete de inicio"
 
 #: src/components/ReportDialog/SelectReportOptionView.tsx:47
 msgid "Report this user"
-msgstr "Denunciar este usuario"
-
-#: src/view/com/util/post-ctrls/RepostButton.tsx:72
-#: src/view/com/util/post-ctrls/RepostButton.tsx:103
-#: src/view/com/util/post-ctrls/RepostButton.tsx:119
-msgctxt "action"
-msgid "Repost"
-msgstr "Denunciar"
+msgstr "Denunciar esta persoa"
 
 #: src/view/com/util/post-ctrls/RepostButton.web.tsx:72
 #: src/view/com/util/post-ctrls/RepostButton.web.tsx:76
 msgid "Repost"
-msgstr ""
+msgstr "Rechouchiar"
 
 #: src/screens/StarterPack/StarterPackScreen.tsx:546
 #: src/view/com/util/post-ctrls/RepostButton.tsx:95
 #: src/view/com/util/post-ctrls/RepostButton.web.tsx:49
 #: src/view/com/util/post-ctrls/RepostButton.web.tsx:104
 msgid "Repost or quote post"
-msgstr ""
+msgstr "Rechouchiar ou citar chío"
 
 #: src/screens/Post/PostRepostedBy.tsx:32
 #: src/screens/Post/PostRepostedBy.tsx:33
 msgid "Reposted By"
-msgstr ""
+msgstr "Rechouchiado por"
 
 #: src/view/com/posts/FeedItem.tsx:294
 msgid "Reposted by {0}"
-msgstr ""
+msgstr "Rechouchiado por {0}"
 
 #: src/view/com/posts/FeedItem.tsx:313
 msgid "Reposted by <0><1/></0>"
-msgstr ""
+msgstr "Rechouchiado por <0><1/></0>"
 
 #: src/view/com/posts/FeedItem.tsx:292
 #: src/view/com/posts/FeedItem.tsx:311
 msgid "Reposted by you"
-msgstr ""
+msgstr "Rechouchiado por ti"
 
 #: src/view/com/notifications/FeedItem.tsx:180
 msgid "reposted your post"
-msgstr ""
+msgstr "volveu publicar o seu chío"
 
 #: src/view/com/post-thread/PostThreadItem.tsx:209
 msgid "Reposts of this post"
-msgstr ""
+msgstr "Rechouchíos deste chío"
 
 #: src/view/com/modals/ChangeEmail.tsx:176
 #: src/view/com/modals/ChangeEmail.tsx:178
 msgid "Request Change"
-msgstr "Solicitar troco"
+msgstr "Solicitar cambio"
 
 #: src/view/com/modals/ChangePassword.tsx:242
 #: src/view/com/modals/ChangePassword.tsx:244
 msgid "Request Code"
-msgstr "Solicitar Código"
+msgstr "Solicitar código"
 
 #: src/view/screens/AccessibilitySettings.tsx:90
 msgid "Require alt text before posting"
-msgstr "Requírese un texto alternativo antes de publicar"
+msgstr "Require texto alternativo antes de publicar"
 
 #: src/view/screens/Settings/Email2FAToggle.tsx:51
 msgid "Require email code to log into your account"
-msgstr "Requírese o código do correo para iniciar sesión na conta"
+msgstr "Solicitar un código de correo electrónico para iniciar sesión na túa conta"
 
 #: src/screens/Signup/StepInfo/index.tsx:159
 msgid "Required for this provider"
-msgstr "Requirido para estes provedor"
+msgstr "Obrigatorio para este provedor"
 
 #: src/components/LabelingServiceCard/index.tsx:80
 msgid "Required in your region"
-msgstr "Requirido na túa rexión"
+msgstr "Obrigatorio na túa rexión"
 
 #: src/view/screens/Settings/DisableEmail2FADialog.tsx:167
 #: src/view/screens/Settings/DisableEmail2FADialog.tsx:170
 msgid "Resend email"
-msgstr "Volver enviar o correo"
+msgstr "Reenviar correo"
 
 #: src/components/dialogs/VerifyEmailDialog.tsx:224
 #: src/components/dialogs/VerifyEmailDialog.tsx:234
 #: src/components/intents/VerifyEmailIntentDialog.tsx:130
 msgid "Resend Email"
-msgstr "Volver enviar o correo"
+msgstr "Reenviar correo"
 
 #: src/components/intents/VerifyEmailIntentDialog.tsx:122
 msgid "Resend Verification Email"
-msgstr "Volver enviar o correo de verificación"
+msgstr "Reenviar correo de verificación"
 
 #: src/view/com/modals/ChangePassword.tsx:186
 msgid "Reset code"
-msgstr "Código de restablecemento"
+msgstr "Código de restablecimento"
 
 #: src/view/com/modals/ChangePassword.tsx:193
 msgid "Reset Code"
-msgstr "Código de restablecemento"
+msgstr "Código de restablecimento"
 
 #: src/view/screens/Settings/index.tsx:867
 #: src/view/screens/Settings/index.tsx:870
 msgid "Reset onboarding state"
-msgstr "Restablecer o estado dos titoriais de benvida"
+msgstr "Restablecer o estado de incorporación"
 
 #: src/screens/Login/ForgotPasswordForm.tsx:80
 msgid "Reset password"
-msgstr "Restablecer contrasinal"
+msgstr "Restablecer o contrasinal"
 
 #: src/view/screens/Settings/index.tsx:847
 #: src/view/screens/Settings/index.tsx:850
 msgid "Reset preferences state"
-msgstr "Restablecer o estado das preferencias"
+msgstr "Restablecer o estado de preferencias"
 
 #: src/view/screens/Settings/index.tsx:868
 msgid "Resets the onboarding state"
-msgstr "Restablece o estado dos titorias de benvida"
+msgstr "Restablece o estado de incorporación"
 
 #: src/view/screens/Settings/index.tsx:848
 msgid "Resets the preferences state"
-msgstr "Restablece o estado das preferencias"
+msgstr "Restablece o estado de preferencias"
 
 #: src/screens/Login/LoginForm.tsx:296
 msgid "Retries login"
-msgstr "Tentar iniciar sesión de novo"
+msgstr "Reintentar o inicio de sesión"
 
 #: src/view/com/util/error/ErrorMessage.tsx:57
 #: src/view/com/util/error/ErrorScreen.tsx:74
 msgid "Retries the last action, which errored out"
-msgstr "Tentar a última acción de novo, que deu erro"
+msgstr "Tenta de novo a última acción, que errou"
 
 #: src/components/dms/MessageItem.tsx:244
 #: src/components/Error.tsx:66
@@ -6004,11 +5516,7 @@ msgstr "Tentar a última acción de novo, que deu erro"
 #: src/view/com/util/post-embeds/VideoEmbedInner/VideoFallback.tsx:55
 #: src/view/com/util/post-embeds/VideoEmbedInner/VideoFallback.tsx:57
 msgid "Retry"
-msgstr "Tentar de novo"
-
-#: src/screens/Messages/Conversation/MessageListError.tsx:54
-#~ msgid "Retry."
-#~ msgstr "Tentar de novo."
+msgstr "Reintentar"
 
 #: src/components/Error.tsx:74
 #: src/screens/List/ListHiddenScreen.tsx:205
@@ -6019,7 +5527,7 @@ msgstr "Volver á páxina anterior"
 
 #: src/view/screens/NotFound.tsx:61
 msgid "Returns to home page"
-msgstr "Volve á páxina principal"
+msgstr "Volve á páxina de inicio"
 
 #: src/view/screens/NotFound.tsx:60
 #: src/view/screens/ProfileFeed.tsx:114
@@ -6044,16 +5552,6 @@ msgstr "Volve á páxina anterior"
 msgid "Save"
 msgstr "Gardar"
 
-#: src/view/com/lightbox/Lightbox.tsx:167
-#: src/view/com/modals/CreateOrEditList.tsx:325
-msgctxt "action"
-msgid "Save"
-msgstr "Gardar"
-
-#: src/view/com/modals/AltImage.tsx:132
-#~ msgid "Save alt text"
-#~ msgstr "Gardar texto alternativo"
-
 #: src/components/dialogs/BirthDateSettings.tsx:118
 msgid "Save birthday"
 msgstr "Gardar aniversario"
@@ -6061,15 +5559,11 @@ msgstr "Gardar aniversario"
 #: src/view/screens/SavedFeeds.tsx:98
 #: src/view/screens/SavedFeeds.tsx:103
 msgid "Save changes"
-msgstr "Gardar trocos"
-
-#: src/view/com/modals/EditProfile.tsx:227
-#~ msgid "Save Changes"
-#~ msgstr "Gardar trocos"
+msgstr "Gardar cambios"
 
 #: src/view/com/modals/ChangeHandle.tsx:158
 msgid "Save handle change"
-msgstr "Gardar troco do nome de usuario"
+msgstr "Gardar cambio de alcume"
 
 #: src/components/StarterPack/ShareDialog.tsx:151
 #: src/components/StarterPack/ShareDialog.tsx:158
@@ -6078,7 +5572,7 @@ msgstr "Gardar imaxe"
 
 #: src/view/com/modals/CropImage.web.tsx:104
 msgid "Save image crop"
-msgstr "Gardar imaxe recortada"
+msgstr "Gardar recorte de imaxe"
 
 #: src/components/StarterPack/QrCodeDialog.tsx:179
 msgid "Save QR code"
@@ -6087,36 +5581,28 @@ msgstr "Gardar código QR"
 #: src/view/screens/ProfileFeed.tsx:338
 #: src/view/screens/ProfileFeed.tsx:344
 msgid "Save to my feeds"
-msgstr "Gardar as miñas fontes"
+msgstr "Gardar nas miñas canles"
 
 #: src/view/screens/SavedFeeds.tsx:171
 msgid "Saved Feeds"
-msgstr "Fontes gardadas"
+msgstr "Canles guardadas"
 
 #: src/view/com/lightbox/Lightbox.tsx:95
 msgid "Saved to your camera roll"
-msgstr "Gardada na túa galería"
-
-#: src/view/com/lightbox/Lightbox.tsx:81
-#~ msgid "Saved to your camera roll."
-#~ msgstr "Gardada na túa galería."
+msgstr "Gardado na galería da cámara"
 
 #: src/view/screens/ProfileFeed.tsx:206
 #: src/view/screens/ProfileList.tsx:366
 msgid "Saved to your feeds"
-msgstr "Gardada nas túas fontes"
-
-#: src/view/com/modals/EditProfile.tsx:220
-#~ msgid "Saves any changes to your profile"
-#~ msgstr "Garda os trocos no teu perfil"
+msgstr "Guardado nas túas canles"
 
 #: src/view/com/modals/ChangeHandle.tsx:159
 msgid "Saves handle change to {handle}"
-msgstr "Garda o troco do nome de usuario en {handle}"
+msgstr "Guarda o cambio de alcume a {handle}"
 
 #: src/view/com/modals/CropImage.web.tsx:105
 msgid "Saves image crop settings"
-msgstr "Garda os axustes de recorte de imaxes"
+msgstr "Guarda os axustes de recorte da imaxe"
 
 #: src/components/dms/ChatEmptyPill.tsx:33
 #: src/components/NewskieDialog.tsx:105
@@ -6132,7 +5618,7 @@ msgstr "Ciencia"
 
 #: src/view/screens/ProfileList.tsx:986
 msgid "Scroll to top"
-msgstr "Ir ao comezo"
+msgstr "Desprázate cara arriba"
 
 #: src/components/dms/dialogs/SearchablePeopleList.tsx:483
 #: src/components/forms/SearchInput.tsx:34
@@ -6144,77 +5630,60 @@ msgstr "Ir ao comezo"
 #: src/view/shell/desktop/LeftNav.tsx:377
 #: src/view/shell/Drawer.tsx:394
 msgid "Search"
-msgstr "Procurar"
+msgstr "Buscar"
 
 #: src/view/shell/desktop/Search.tsx:201
 msgid "Search for \"{query}\""
-msgstr "Procurar \"{query}\""
+msgstr "Buscar \"{query}\""
 
 #: src/view/screens/Search/Search.tsx:999
 msgid "Search for \"{searchText}\""
-msgstr "Procurar \"{searchText}\""
-
-#: src/components/TagMenu/index.tsx:155
-#~ msgid "Search for all posts by @{authorHandle} with tag {displayTag}"
-#~ msgstr "Procurar todas as publicacións de @{authorHandle} coa etiqueta {displayTag}"
-
-#: src/components/TagMenu/index.tsx:104
-#~ msgid "Search for all posts with tag {displayTag}"
-#~ msgstr "Procurar todas as publicacións coa etiqueta {displayTag}"
+msgstr "Buscar \"{searchText}\""
 
 #: src/screens/StarterPack/Wizard/index.tsx:500
 msgid "Search for feeds that you want to suggest to others."
-msgstr "Procurar fontes que queres suxerir a outros."
-
-#: src/components/dms/NewChat.tsx:226
-#~ msgid "Search for someone to start a conversation with."
-#~ msgstr "Procurar alguén para iniciar unha conversa."
+msgstr "Busca canles que queiras suxerir aos demais."
 
 #: src/view/com/modals/ListAddRemoveUsers.tsx:71
 msgid "Search for users"
-msgstr "Procurar usuarios"
+msgstr "Buscar persoas"
 
 #: src/components/dialogs/GifSelect.tsx:177
 msgid "Search GIFs"
-msgstr "Procurar GIFs"
+msgstr "Buscar GIFs"
 
 #: src/components/dms/dialogs/SearchablePeopleList.tsx:503
 #: src/components/dms/dialogs/SearchablePeopleList.tsx:504
 msgid "Search profiles"
-msgstr "Procurar perfís"
+msgstr "Buscar perfís"
 
 #: src/components/dialogs/GifSelect.tsx:178
 msgid "Search Tenor"
-msgstr ""
+msgstr "Buscar en Tenor"
 
 #: src/view/com/modals/ChangeEmail.tsx:105
 msgid "Security Step Required"
-msgstr ""
+msgstr "Requírese un paso de seguridade"
 
 #: src/components/TagMenu/index.web.tsx:77
 msgid "See {truncatedTag} posts"
-msgstr ""
+msgstr "Ver chíos de {truncatedTag}"
 
 #: src/components/TagMenu/index.web.tsx:94
 msgid "See {truncatedTag} posts by user"
-msgstr ""
+msgstr "Ver chíos de {truncatedTag} por esta persoa"
 
 #: src/components/TagMenu/index.tsx:132
 msgid "See <0>{displayTag}</0> posts"
-msgstr ""
+msgstr "Ver chíos de <0>{displayTag}</0>"
 
 #: src/components/TagMenu/index.tsx:183
 msgid "See <0>{displayTag}</0> posts by this user"
-msgstr ""
+msgstr "Ver chíos de <0>{displayTag}</0> por esta persoa"
 
 #: src/view/com/auth/SplashScreen.web.tsx:175
 msgid "See jobs at Bluesky"
-msgstr "Ver traballos en Bluesky"
-
-#: src/view/com/notifications/FeedItem.tsx:411
-#: src/view/com/util/UserAvatar.tsx:402
-#~ msgid "See profile"
-#~ msgstr "Ver perfil"
+msgstr "Ver empregos en Bluesky"
 
 #: src/view/screens/SavedFeeds.tsx:212
 msgid "See this guide"
@@ -6222,7 +5691,7 @@ msgstr "Ver esta guía"
 
 #: src/view/com/util/post-embeds/VideoEmbedInner/web-controls/Scrubber.tsx:189
 msgid "Seek slider"
-msgstr "Barra de desprazamento de busca"
+msgstr "Control deslizante de busca"
 
 #: src/view/com/util/Selector.tsx:106
 msgid "Select {item}"
@@ -6230,7 +5699,7 @@ msgstr "Seleccionar {item}"
 
 #: src/screens/Onboarding/StepProfile/AvatarCreatorItems.tsx:67
 msgid "Select a color"
-msgstr "Seleccionar unha cor"
+msgstr "Selecciona unha cor"
 
 #: src/screens/Login/ChooseAccountForm.tsx:77
 msgid "Select account"
@@ -6238,15 +5707,15 @@ msgstr "Seleccionar conta"
 
 #: src/screens/Onboarding/StepProfile/AvatarCircle.tsx:66
 msgid "Select an avatar"
-msgstr "Seleccionar un avatar"
+msgstr "Selecciona un avatar"
 
 #: src/screens/Onboarding/StepProfile/AvatarCreatorItems.tsx:65
 msgid "Select an emoji"
-msgstr "Seleccionar un emoji"
+msgstr "Selecciona un emoji"
 
 #: src/screens/Login/index.tsx:117
 msgid "Select from an existing account"
-msgstr "Seleccionar dunha conta existente"
+msgstr "Selecciona unha conta existente"
 
 #: src/view/com/composer/photos/SelectGifBtn.tsx:35
 msgid "Select GIF"
@@ -6258,15 +5727,15 @@ msgstr "Seleccionar GIF \"{0}\""
 
 #: src/components/dialogs/MutedWords.tsx:142
 msgid "Select how long to mute this word for."
-msgstr "Seleccionar por canto tempo debe ser silenciada esta palabra."
+msgstr "Selecciona durante canto tempo queres silenciar esta palabra."
 
 #: src/view/com/composer/videos/SubtitleDialog.tsx:245
 msgid "Select language..."
-msgstr "Seleccionar lingua..."
+msgstr "Seleccionar idioma..."
 
 #: src/view/screens/LanguageSettings.tsx:301
 msgid "Select languages"
-msgstr "Seleccionar linguas"
+msgstr "Seleccionar idiomas"
 
 #: src/components/ReportDialog/SelectLabelerView.tsx:29
 msgid "Select moderator"
@@ -6276,29 +5745,21 @@ msgstr "Seleccionar moderador"
 msgid "Select option {i} of {numItems}"
 msgstr "Seleccionar opción {i} de {numItems}"
 
-#: src/screens/Onboarding/StepSuggestedAccounts/index.tsx:52
-#~ msgid "Select some accounts below to follow"
-#~ msgstr "Seleccionar abaixo algunhas contas para seguir"
-
 #: src/view/com/composer/videos/SubtitleFilePicker.tsx:66
 msgid "Select subtitle file (.vtt)"
-msgstr "Seleccionar ficheiro de subtítulos (.vtt)"
+msgstr "Seleccionar lexendaxe (.vtt)"
 
 #: src/screens/Onboarding/StepProfile/AvatarCreatorItems.tsx:83
 msgid "Select the {emojiName} emoji as your avatar"
-msgstr "Seleccionar o emoji {emojiName} coma o teu avatar"
+msgstr "Seleccionar o emoji {emojiName} como o teu avatar"
 
 #: src/components/ReportDialog/SubmitView.tsx:140
 msgid "Select the moderation service(s) to report to"
-msgstr "Seleccionar o servizo(s) de moderación a denunciar"
+msgstr "Selecciona o(s) servizo(s) de moderación aos que queres informar"
 
 #: src/view/com/auth/server-input/index.tsx:79
 msgid "Select the service that hosts your data."
-msgstr "Selecciona o servizo que hospeda os teus datos."
-
-#: src/screens/Onboarding/StepTopicalFeeds.tsx:100
-#~ msgid "Select topical feeds to follow from the list below"
-#~ msgstr "Seleccionar da seguinte lista fontes de actualidade par seguir"
+msgstr "Seleccione o servizo que aloxa os seus datos."
 
 #: src/view/com/composer/videos/SelectVideoBtn.tsx:106
 msgid "Select video"
@@ -6306,47 +5767,39 @@ msgstr "Seleccionar vídeo"
 
 #: src/components/dialogs/MutedWords.tsx:242
 msgid "Select what content this mute word should apply to."
-msgstr "Seleccionar a que contido esta palabra silenciada debe ser aplicada."
-
-#: src/screens/Onboarding/StepModeration/index.tsx:63
-#~ msgid "Select what you want to see (or not see), and we’ll handle the rest."
-#~ msgstr "Selecciona o que desexas ver e nós Elige lo que quieres ver y nosotros nos encargaremos del resto."
+msgstr "Selecciona a que contido debería aplicarse esta palabra silenciada."
 
 #: src/view/screens/LanguageSettings.tsx:283
-msgid "Select which languages you want your subscribed feeds to include. If none are selected, all languages will be shown."
-msgstr "Selecciona as linguas que desexas ver nas fontes ás que estas subscrito. Se non seleccionas ningunha, amosaranse todas."
+msgid ""
+"Select which languages you want your subscribed feeds to include. If none "
+"are selected, all languages will be shown."
+msgstr ""
+"Elixe en que idiomas desexas que estean os chíos das túas canles. Se non "
+"seleccionas ningún, mostraranse en todos os idiomas."
 
 #: src/view/screens/LanguageSettings.tsx:97
 msgid "Select your app language for the default text to display in the app."
-msgstr "Selecciona a lingua da aplicación."
+msgstr "Elixe en que idioma queres que estea Bluesky."
 
 #: src/screens/Signup/StepInfo/index.tsx:223
 msgid "Select your date of birth"
-msgstr "Selecciona a túa data de nacemento"
+msgstr "Seleccione a túa data de nacemento"
 
 #: src/screens/Onboarding/StepInterests/index.tsx:192
 msgid "Select your interests from the options below"
-msgstr "Selecciona os teus intereses nas opcións de abaixo"
+msgstr "Seleccione os teus intereses entre as seguintes opcións"
 
 #: src/view/screens/LanguageSettings.tsx:191
 msgid "Select your preferred language for translations in your feed."
-msgstr "Selecciona a túa lingua preferida para as traducións na túa fonte."
-
-#: src/screens/Onboarding/StepAlgoFeeds/index.tsx:117
-#~ msgid "Select your primary algorithmic feeds"
-#~ msgstr "Selecciona o algoritmo principal das túas fontes"
-
-#: src/screens/Onboarding/StepAlgoFeeds/index.tsx:133
-#~ msgid "Select your secondary algorithmic feeds"
-#~ msgstr "Selecciona o algoritmo secundario das túas fontes"
+msgstr "A que idioma queres traducir os chíos na túa canle."
 
 #: src/components/dms/ChatEmptyPill.tsx:38
 msgid "Send a neat website!"
-msgstr "Enviar un sitio web interesante!"
+msgstr "Envía un sitio web interesante!"
 
 #: src/components/dialogs/VerifyEmailDialog.tsx:189
 msgid "Send Confirmation"
-msgstr "Enviar Confirmación"
+msgstr "Enviar confirmación"
 
 #: src/components/dialogs/VerifyEmailDialog.tsx:182
 msgid "Send confirmation email"
@@ -6355,20 +5808,15 @@ msgstr "Enviar correo de confirmación"
 #: src/view/com/modals/VerifyEmail.tsx:210
 #: src/view/com/modals/VerifyEmail.tsx:212
 msgid "Send Confirmation Email"
-msgstr "Enviar Correo de Confirmación"
+msgstr "Enviar correo de confirmación"
 
 #: src/view/com/modals/DeleteAccount.tsx:149
 msgid "Send email"
 msgstr "Enviar correo"
 
-#: src/view/com/modals/DeleteAccount.tsx:162
-msgctxt "action"
-msgid "Send Email"
-msgstr "Enviar Correo"
-
 #: src/view/shell/Drawer.tsx:341
 msgid "Send feedback"
-msgstr "Enviar comentario"
+msgstr "Enviar comentarios"
 
 #: src/screens/Messages/components/MessageInput.tsx:165
 #: src/screens/Messages/components/MessageInput.web.tsx:219
@@ -6377,18 +5825,18 @@ msgstr "Enviar mensaxe"
 
 #: src/components/dms/dialogs/ShareViaChatDialog.tsx:62
 msgid "Send post to..."
-msgstr "Enviar publicación a..."
+msgstr "Enviar chío a..."
 
 #: src/components/dms/ReportDialog.tsx:229
 #: src/components/dms/ReportDialog.tsx:232
 #: src/components/ReportDialog/SubmitView.tsx:220
 #: src/components/ReportDialog/SubmitView.tsx:224
 msgid "Send report"
-msgstr "Enviar denuncia"
+msgstr "Enviar reporte"
 
 #: src/components/ReportDialog/SelectLabelerView.tsx:43
 msgid "Send report to {0}"
-msgstr "Enviar denuncia a {0}"
+msgstr "Enviar reporte a {0}"
 
 #: src/view/screens/Settings/DisableEmail2FADialog.tsx:118
 #: src/view/screens/Settings/DisableEmail2FADialog.tsx:121
@@ -6398,11 +5846,13 @@ msgstr "Enviar correo de verificación"
 #: src/view/com/util/forms/PostDropdownBtn.tsx:441
 #: src/view/com/util/forms/PostDropdownBtn.tsx:444
 msgid "Send via direct message"
-msgstr "Enviar a través de mensaxe directa"
+msgstr "Enviar vía mensaxe directa"
 
 #: src/view/com/modals/DeleteAccount.tsx:151
 msgid "Sends email with confirmation code for account deletion"
-msgstr "Envia un correo co código de confirmación para a eliminación da conta"
+msgstr ""
+"Envía un correo electrónico co código de confirmación para a eliminación da "
+"conta"
 
 #: src/view/com/auth/server-input/index.tsx:111
 msgid "Server address"
@@ -6410,31 +5860,47 @@ msgstr "Enderezo do servidor"
 
 #: src/screens/Moderation/index.tsx:317
 msgid "Set birthdate"
-msgstr "Definir data de nacemento"
+msgstr "Establecer aniversario"
 
 #: src/screens/Login/SetNewPasswordForm.tsx:96
 msgid "Set new password"
-msgstr "Definir novo contrasinal"
+msgstr "Establecer un novo contrasinal"
 
 #: src/view/screens/PreferencesFollowingFeed.tsx:122
-msgid "Set this setting to \"No\" to hide all quote posts from your feed. Reposts will still be visible."
+msgid ""
+"Set this setting to \"No\" to hide all quote posts from your feed. Reposts "
+"will still be visible."
 msgstr ""
+"Establece esta opción en \"Non\" para ocultar todos os chíos citados das "
+"túas canles. Os rechouchíos seguirán sendo visíbeis."
 
 #: src/view/screens/PreferencesFollowingFeed.tsx:64
 msgid "Set this setting to \"No\" to hide all replies from your feed."
-msgstr "Definir este axuste a \"Non\" para ocultar todas as respostas da túa fonte."
+msgstr ""
+"Establece esta opción en \"Non\" para ocultar todas as respostas das túas "
+"canles."
 
 #: src/view/screens/PreferencesFollowingFeed.tsx:88
 msgid "Set this setting to \"No\" to hide all reposts from your feed."
 msgstr ""
+"Establece esta configuración en \"Non\" para ocultar todos os chíos das "
+"túas canles."
 
 #: src/view/screens/PreferencesThreads.tsx:117
-msgid "Set this setting to \"Yes\" to show replies in a threaded view. This is an experimental feature."
+msgid ""
+"Set this setting to \"Yes\" to show replies in a threaded view. This is an "
+"experimental feature."
 msgstr ""
+"Establece este axuste en \"Si\" para mostrar as respostas nunha vista de "
+"fíos. Trátase dunha función experimental."
 
 #: src/view/screens/PreferencesFollowingFeed.tsx:158
-msgid "Set this setting to \"Yes\" to show samples of your saved feeds in your Following feed. This is an experimental feature."
+msgid ""
+"Set this setting to \"Yes\" to show samples of your saved feeds in your "
+"Following feed. This is an experimental feature."
 msgstr ""
+"Establece este axuste en \"Si\" para mostrar mostras das túas canles "
+"guardadas nas túas canles de Seguindo. Esta é unha función experimental."
 
 #: src/screens/Onboarding/Layout.tsx:48
 msgid "Set up your account"
@@ -6442,43 +5908,11 @@ msgstr "Configura a túa conta"
 
 #: src/view/com/modals/ChangeHandle.tsx:254
 msgid "Sets Bluesky username"
-msgstr "Define o nome de usuario de Bluesky"
-
-#: src/view/screens/Settings/index.tsx:463
-#~ msgid "Sets color theme to dark"
-#~ msgstr "Define o tema de cor a escuro"
-
-#: src/view/screens/Settings/index.tsx:456
-#~ msgid "Sets color theme to light"
-#~ msgstr "Define o tema de cor a claro"
-
-#: src/view/screens/Settings/index.tsx:450
-#~ msgid "Sets color theme to system setting"
-#~ msgstr "Define o tema de cor segundo o do sistema"
-
-#: src/view/screens/Settings/index.tsx:489
-#~ msgid "Sets dark theme to the dark theme"
-#~ msgstr ""
-
-#: src/view/screens/Settings/index.tsx:482
-#~ msgid "Sets dark theme to the dim theme"
-#~ msgstr ""
+msgstr "Establece o alcume de Bluesky"
 
 #: src/screens/Login/ForgotPasswordForm.tsx:107
 msgid "Sets email for password reset"
-msgstr "Definir o correo para restablecer o contrasinal"
-
-#: src/view/com/modals/crop-image/CropImage.web.tsx:146
-#~ msgid "Sets image aspect ratio to square"
-#~ msgstr "Define a relación de aspecto da imaxe a cadrado"
-
-#: src/view/com/modals/crop-image/CropImage.web.tsx:136
-#~ msgid "Sets image aspect ratio to tall"
-#~ msgstr "Define a relación de aspecto da imaxe a alto"
-
-#: src/view/com/modals/crop-image/CropImage.web.tsx:126
-#~ msgid "Sets image aspect ratio to wide"
-#~ msgstr "Define a relación de aspecto da imaxe a largo"
+msgstr "Establece o correo electrónico para restablecer o contrasinal"
 
 #: src/Navigation.tsx:154
 #: src/view/screens/Settings/index.tsx:303
@@ -6507,37 +5941,24 @@ msgstr "Sexualmente suxestivo"
 msgid "Share"
 msgstr "Compartir"
 
-#: src/view/com/lightbox/Lightbox.tsx:176
-msgctxt "action"
-msgid "Share"
-msgstr "Compartir"
-
 #: src/components/dms/ChatEmptyPill.tsx:37
 msgid "Share a cool story!"
-msgstr "Comparte unha boa historia!"
+msgstr "Comparte unha historia xenial!"
 
 #: src/components/dms/ChatEmptyPill.tsx:36
 msgid "Share a fun fact!"
-msgstr "Comparte un feito divertido!"
+msgstr "Comparte un dato curioso!"
 
 #: src/view/com/profile/ProfileMenu.tsx:353
 #: src/view/com/util/forms/PostDropdownBtn.tsx:703
 #: src/view/com/util/post-ctrls/PostCtrls.tsx:349
 msgid "Share anyway"
-msgstr "Compartir de todos os xeitos"
+msgstr "Compartir de todas as maneiras"
 
 #: src/view/screens/ProfileFeed.tsx:364
 #: src/view/screens/ProfileFeed.tsx:366
 msgid "Share feed"
-msgstr "Compartir fonte"
-
-#: src/components/dialogs/nuxs/TenMillion/index.tsx:621
-#~ msgid "Share image externally"
-#~ msgstr "Compartir a imaxe externamente"
-
-#: src/components/dialogs/nuxs/TenMillion/index.tsx:639
-#~ msgid "Share image in post"
-#~ msgstr "Compartir a imaxe nunha publicación"
+msgstr "Compartir canle"
 
 #: src/components/StarterPack/ShareDialog.tsx:124
 #: src/components/StarterPack/ShareDialog.tsx:131
@@ -6552,7 +5973,7 @@ msgstr "Compartir Ligazón"
 
 #: src/components/StarterPack/ShareDialog.tsx:88
 msgid "Share link dialog"
-msgstr "Diálogo para compartir ligazón"
+msgstr "Xanela para compartir ligazón"
 
 #: src/components/StarterPack/ShareDialog.tsx:135
 #: src/components/StarterPack/ShareDialog.tsx:146
@@ -6565,159 +5986,113 @@ msgstr "Compartir este paquete de inicio"
 
 #: src/components/StarterPack/ShareDialog.tsx:100
 msgid "Share this starter pack and help people join your community on Bluesky."
-msgstr "Comparte este paquete de inicio e axuda á xente a unirse á comunidade do Bluesky."
+msgstr ""
+"Comparte este paquete de iniciación e axuda a xente a unirse á túa "
+"comunidade en Bluesky."
 
 #: src/components/dms/ChatEmptyPill.tsx:34
 msgid "Share your favorite feed!"
-msgstr "Comparte a túa fonte favorita!"
+msgstr "Comparte as túas canles favoritas!"
 
 #: src/Navigation.tsx:250
 msgid "Shared Preferences Tester"
-msgstr "Probador de preferencias compartidas"
+msgstr "Probador de Preferencias Compartidas"
 
 #: src/view/com/modals/LinkWarning.tsx:92
 msgid "Shares the linked website"
-msgstr "Comparte o sitio web vinculado"
+msgstr "Comparte o sitio web ligado"
 
 #: src/components/moderation/ContentHider.tsx:178
 #: src/components/moderation/LabelPreference.tsx:136
 #: src/components/moderation/PostHider.tsx:122
 #: src/view/screens/Settings/index.tsx:352
 msgid "Show"
-msgstr "Amosar"
-
-#: src/view/screens/Search/Search.tsx:889
-#~ msgid "Show advanced filters"
-#~ msgstr "Amosar filtros avanzados"
-
-#: src/view/screens/PreferencesFollowingFeed.tsx:68
-#~ msgid "Show all replies"
-#~ msgstr "Amosar todas as respostas"
+msgstr "Ver"
 
 #: src/view/com/util/post-embeds/GifEmbed.tsx:178
 msgid "Show alt text"
-msgstr "Amosar texto alternativo"
+msgstr "Ver texto alternativo"
 
 #: src/components/moderation/ScreenHider.tsx:172
 #: src/components/moderation/ScreenHider.tsx:175
 #: src/screens/List/ListHiddenScreen.tsx:176
 msgid "Show anyway"
-msgstr "Amosar de todos os xeitos"
+msgstr "Ver de todas as maneiras"
 
 #: src/lib/moderation/useLabelBehaviorDescription.ts:27
 #: src/lib/moderation/useLabelBehaviorDescription.ts:63
 msgid "Show badge"
-msgstr "Amosar insignia"
+msgstr "Mostrar distintivo"
 
 #: src/lib/moderation/useLabelBehaviorDescription.ts:61
 msgid "Show badge and filter from feeds"
-msgstr "Amosar insignia e filtrar polas fontes"
-
-#: src/screens/Profile/Header/ProfileHeaderStandard.tsx:215
-#~ msgid "Show follows similar to {0}"
-#~ msgstr ""
+msgstr "Mostra a insignia e filtra desde as canles"
 
 #: src/view/com/post-thread/PostThreadShowHiddenReplies.tsx:23
 msgid "Show hidden replies"
-msgstr "Amosar respostas ocultas"
+msgstr "Mostrar respostas ocultas"
 
 #: src/view/com/util/forms/PostDropdownBtn.tsx:491
 #: src/view/com/util/forms/PostDropdownBtn.tsx:493
 msgid "Show less like this"
-msgstr "Amosar menos coma isto"
+msgstr "Mostrar menos como este"
 
 #: src/screens/List/ListHiddenScreen.tsx:172
 msgid "Show list anyway"
-msgstr "Amosar a lista de todos os xeitos"
+msgstr "Mostrar listaxe de todas as maneiras"
 
 #: src/view/com/post-thread/PostThreadItem.tsx:580
 #: src/view/com/post/Post.tsx:233
 #: src/view/com/posts/FeedItem.tsx:500
 msgid "Show More"
-msgstr "Amosar máis"
+msgstr "Ver máis"
 
 #: src/view/com/util/forms/PostDropdownBtn.tsx:483
 #: src/view/com/util/forms/PostDropdownBtn.tsx:485
 msgid "Show more like this"
-msgstr "Amosar máis coma isto"
+msgstr "Mostrar máis como este"
 
 #: src/view/com/post-thread/PostThreadShowHiddenReplies.tsx:23
 msgid "Show muted replies"
-msgstr "Amosar respostas silenciadas"
+msgstr "Mostrar respostas silenciadas"
 
 #: src/view/screens/PreferencesFollowingFeed.tsx:155
 msgid "Show Posts from My Feeds"
-msgstr "Amosar publicacións das miñas fontes"
+msgstr "Mostrar chíos das miñas canles"
 
 #: src/view/screens/PreferencesFollowingFeed.tsx:119
 msgid "Show Quote Posts"
-msgstr "Amosar publicacións citadas"
-
-#: src/screens/Onboarding/StepFollowingFeed.tsx:119
-#~ msgid "Show quote-posts in Following feed"
-#~ msgstr ""
-
-#: src/screens/Onboarding/StepFollowingFeed.tsx:135
-#~ msgid "Show quotes in Following"
-#~ msgstr "Amosar citas no Seguindo"
-
-#: src/screens/Onboarding/StepFollowingFeed.tsx:95
-#~ msgid "Show re-posts in Following feed"
-#~ msgstr ""
+msgstr "Mostrar chíos de citas"
 
 #: src/view/screens/PreferencesFollowingFeed.tsx:61
 msgid "Show Replies"
-msgstr "Amosar respostas"
+msgstr "Mostrar respostas"
 
 #: src/view/screens/PreferencesThreads.tsx:95
 msgid "Show replies by people you follow before all other replies."
-msgstr"Amosar as respostas das persoas que sigues antes que outras respostas."
-
-#: src/screens/Onboarding/StepFollowingFeed.tsx:87
-#~ msgid "Show replies in Following"
-#~ msgstr "Amosar respostas no Seguindo"
-
-#: src/screens/Onboarding/StepFollowingFeed.tsx:71
-#~ msgid "Show replies in Following feed"
-#~ msgstr "Amosar respostas na fonte de Seguindo"
-
-#: src/view/screens/PreferencesFollowingFeed.tsx:70
-#~ msgid "Show replies with at least {value} {0}"
-#~ msgstr "Amosar respostas con cando menos {value} {0}"
+msgstr "Mostra as respostas das persoas que segues antes que as demais."
 
 #: src/view/com/util/forms/PostDropdownBtn.tsx:559
 #: src/view/com/util/forms/PostDropdownBtn.tsx:569
 msgid "Show reply for everyone"
-msgstr "Amosar respostas para todos"
+msgstr "Mostrar resposta para todo o mundo"
 
 #: src/view/screens/PreferencesFollowingFeed.tsx:85
 msgid "Show Reposts"
-msgstr ""
-
-#: src/screens/Onboarding/StepFollowingFeed.tsx:111
-#~ msgid "Show reposts in Following"
-#~ msgstr ""
+msgstr "Mostrar rechouchíos"
 
 #: src/components/moderation/ContentHider.tsx:130
 #: src/components/moderation/PostHider.tsx:79
 msgid "Show the content"
-msgstr "Amosar o contido"
-
-#: src/view/com/notifications/FeedItem.tsx:347
-#~ msgid "Show users"
-#~ msgstr "Amosar usuarios"
+msgstr "Mostrar o contido"
 
 #: src/lib/moderation/useLabelBehaviorDescription.ts:58
 msgid "Show warning"
-msgstr "Amosar aviso"
+msgstr "Mostrar advertencia"
 
 #: src/lib/moderation/useLabelBehaviorDescription.ts:56
 msgid "Show warning and filter from feeds"
-msgstr "Amosar avisos e filtrar polas fontes"
-
-#: src/view/com/post-thread/PostThreadFollowBtn.tsx:128
-#~ msgid "Shows posts from {0} in your feed"
-#~ msgstr "Amosar publicacións de {0} na túa fonte"
+msgstr "Mostrar advertencia e filtrar desde as canles"
 
 #: src/components/dialogs/Signin.tsx:97
 #: src/components/dialogs/Signin.tsx:99
@@ -6745,24 +6120,24 @@ msgstr "Iniciar sesión como {0}"
 
 #: src/screens/Login/ChooseAccountForm.tsx:80
 msgid "Sign in as..."
-msgstr "Iniciar sesión como..."
+msgstr "Iniciar sesión como ..."
 
 #: src/components/dialogs/Signin.tsx:75
 msgid "Sign in or create your account to join the conversation!"
-msgstr "Iniciar sesión ou crear unha conta para unirse á conversa!"
+msgstr "Inicia sesión ou crea a túa conta para unirte á conversa!"
 
 #: src/components/dialogs/Signin.tsx:46
 msgid "Sign into Bluesky or create a new account"
-msgstr "Iniciar sesión no Bluesky ou crear unha conta nova"
+msgstr "Inicia sesión en Bluesky ou crea unha nova conta"
 
 #: src/view/screens/Settings/index.tsx:433
 msgid "Sign out"
-msgstr "Saír"
+msgstr "Pechar sesión"
 
 #: src/view/screens/Settings/index.tsx:421
 #: src/view/screens/Settings/index.tsx:431
 msgid "Sign out of all accounts"
-msgstr "Saír de todas as contas"
+msgstr "Pechar sesión de todas as contas"
 
 #: src/view/shell/bottom-bar/BottomBar.tsx:301
 #: src/view/shell/bottom-bar/BottomBar.tsx:302
@@ -6773,11 +6148,7 @@ msgstr "Saír de todas as contas"
 #: src/view/shell/NavSignupCard.tsx:47
 #: src/view/shell/NavSignupCard.tsx:52
 msgid "Sign up"
-msgstr "Rexistrarse"
-
-#: src/view/shell/NavSignupCard.tsx:47
-#~ msgid "Sign up or sign in to join the conversation"
-#~ msgstr "Crea unha conta ou inicia sesión para unirte á converza"
+msgstr "Crear conta"
 
 #: src/components/moderation/ScreenHider.tsx:91
 #: src/lib/moderation/useGlobalLabelStrings.ts:28
@@ -6786,81 +6157,77 @@ msgstr "É necesario iniciar sesión"
 
 #: src/view/screens/Settings/index.tsx:362
 msgid "Signed in as"
-msgstr "Entraches coma"
+msgstr "Sesión iniciada como"
 
 #: src/lib/hooks/useAccountSwitcher.ts:41
 #: src/screens/Login/ChooseAccountForm.tsx:53
 msgid "Signed in as @{0}"
-msgstr "Entraches coma @{0}"
+msgstr "Sesión iniciada como @{0}"
 
 #: src/view/com/notifications/FeedItem.tsx:218
 msgid "signed up with your starter pack"
-msgstr "entraches co teu paquete de inicio"
+msgstr "rexistrarte co teu paquete de inicio"
 
 #: src/screens/StarterPack/StarterPackLandingScreen.tsx:299
 #: src/screens/StarterPack/StarterPackLandingScreen.tsx:306
 msgid "Signup without a starter pack"
-msgstr "Entraches sen o teu paquete de inicio"
+msgstr "Rexístrate sen un paquete de inicio"
 
 #: src/components/FeedInterstitials.tsx:316
 msgid "Similar accounts"
-msgstr "Contas semellantes"
+msgstr "Contas similares"
 
 #: src/screens/Onboarding/StepInterests/index.tsx:231
 #: src/screens/StarterPack/Wizard/index.tsx:200
 msgid "Skip"
-msgstr "Omitir"
+msgstr "Saltar"
 
 #: src/screens/Onboarding/StepInterests/index.tsx:228
 msgid "Skip this flow"
-msgstr ""
+msgstr "Saltar este flujo"
 
 #: src/components/dialogs/nuxs/NeueTypography.tsx:95
 #: src/screens/Settings/AppearanceSettings.tsx:165
 msgid "Smaller"
-msgstr ""
+msgstr "Máis pequeno"
 
 #: src/screens/Onboarding/index.tsx:37
 #: src/screens/Onboarding/state.ts:87
 msgid "Software Dev"
-msgstr ""
+msgstr "Programación"
 
 #: src/components/FeedInterstitials.tsx:447
 msgid "Some other feeds you might like"
-msgstr ""
+msgstr "Algunha outra canle poderiache gustar"
 
 #: src/components/WhoCanReply.tsx:70
 msgid "Some people can reply"
 msgstr "Algunhas persoas poden responder"
 
-#: src/screens/StarterPack/Wizard/index.tsx:203
-#~ msgid "Some subtitle"
-#~ msgstr "Algún subtítulo"
-
 #: src/screens/Messages/Conversation.tsx:109
 msgid "Something went wrong"
-msgstr "Algo foi mal"
+msgstr "Algo saíu mal"
 
 #: src/screens/Deactivated.tsx:94
 #: src/screens/Settings/components/DeactivateAccountDialog.tsx:59
 msgid "Something went wrong, please try again"
-msgstr "Algo foi mal, por favor téntao de novo"
+msgstr "Produciuse un erro, téntao de novo"
 
 #: src/components/ReportDialog/index.tsx:54
 #: src/screens/Moderation/index.tsx:117
 #: src/screens/Profile/Sections/Labels.tsx:87
 msgid "Something went wrong, please try again."
-msgstr "Algo foi mal, por favor téntao de novo."
+msgstr "Produciuse un erro, téntao de novo."
 
 #: src/components/Lists.tsx:200
 #: src/view/screens/NotificationsSettings.tsx:49
 msgid "Something went wrong!"
-msgstr "Algo foi mal!"
+msgstr "Algo saíu mal!"
 
 #: src/App.native.tsx:112
 #: src/App.web.tsx:95
 msgid "Sorry! Your session expired. Please log in again."
-msgstr "Sentímolo! A túa sesión caducou. Por favor, entra de novo."
+msgstr "Sentímolo! A túa sesión caducou. Inicia sesión de novo."
 
 #: src/view/screens/PreferencesThreads.tsx:64
 msgid "Sort Replies"
@@ -6868,19 +6235,11 @@ msgstr "Ordenar respostas"
 
 #: src/view/screens/PreferencesThreads.tsx:67
 msgid "Sort replies to the same post by:"
-msgstr ""
+msgstr "Ordena as respostas ao mesmo. chío por:"
 
 #: src/components/moderation/LabelsOnMeDialog.tsx:168
 msgid "Source:"
 msgstr "Fonte:"
-
-#: src/components/moderation/LabelsOnMeDialog.tsx:169
-#~ msgid "Source: <0>{0}</0>"
-#~ msgstr "Fonte: <0>{0}</0>"
-
-#: src/components/moderation/LabelsOnMeDialog.tsx:163
-#~ msgid "Source: <0>{sourceName}</0>"
-#~ msgstr "Fonte: <0>{sourceName}</0>"
 
 #: src/lib/moderation/useReportOptions.ts:72
 #: src/lib/moderation/useReportOptions.ts:85
@@ -6896,25 +6255,13 @@ msgstr "Spam; mencións ou respostas excesivas"
 msgid "Sports"
 msgstr "Deportes"
 
-#: src/view/com/modals/crop-image/CropImage.web.tsx:145
-#~ msgid "Square"
-#~ msgstr "Cadrado"
-
 #: src/components/dms/dialogs/NewChatDialog.tsx:61
 msgid "Start a new chat"
-msgstr "Iniciar unha nova conversa"
+msgstr "Iniciar un novo chat"
 
 #: src/components/dms/dialogs/SearchablePeopleList.tsx:349
 msgid "Start chat with {displayName}"
-msgstr "Iniciar conversa con {displayName}"
-
-#: src/components/dms/MessagesNUX.tsx:161
-#~ msgid "Start chatting"
-#~ msgstr "Iniciar conversa"
-
-#: src/tours/Tooltip.tsx:99
-#~ msgid "Start of onboarding tour window. Do not move backward. Instead, go forward for more options, or press to skip."
-#~ msgstr "Comezar o percorrido de benvida. Non retrocedas. No seu lugar, vai cara adiante para máis opcións ou preme en omitir."
+msgstr "Iniciar chat con {displayName}"
 
 #: src/Navigation.tsx:357
 #: src/Navigation.tsx:362
@@ -6924,11 +6271,11 @@ msgstr "Paquete de inicio"
 
 #: src/components/StarterPack/StarterPackCard.tsx:81
 msgid "Starter pack by {0}"
-msgstr "Paquete de inicio por {0}"
+msgstr "Paquete de inicio de {0}"
 
 #: src/components/StarterPack/StarterPackCard.tsx:80
 msgid "Starter pack by you"
-msgstr ""
+msgstr "Paquete de inicio creado por ti"
 
 #: src/screens/StarterPack/StarterPackScreen.tsx:714
 msgid "Starter pack is invalid"
@@ -6939,16 +6286,16 @@ msgid "Starter Packs"
 msgstr "Paquetes de inicio"
 
 #: src/components/StarterPack/ProfileStarterPacks.tsx:239
-msgid "Starter packs let you easily share your favorite feeds and people with your friends."
-msgstr "Os paquetes de inicio permítenche compartir dun xeito doado as túas fontes e xente favoritas cos teus amigos."
+msgid ""
+"Starter packs let you easily share your favorite feeds and people with your "
+"friends."
+msgstr ""
+"Os paquetes de inicio permítenche compartir facilmente as túas canles e "
+"persoas favoritas coas túas amizades."
 
 #: src/view/screens/Settings/index.tsx:918
 msgid "Status Page"
 msgstr "Páxina de estado"
-
-#: src/screens/Signup/index.tsx:145
-#~ msgid "Step"
-#~ msgstr "Paso"
 
 #: src/screens/Signup/index.tsx:130
 msgid "Step {0} of {1}"
@@ -6956,12 +6303,12 @@ msgstr "Paso {0} de {1}"
 
 #: src/view/screens/Settings/index.tsx:279
 msgid "Storage cleared, you need to restart the app now."
-msgstr "Almacenamento baleirado, é preciso reiniciar a aplicación agora."
+msgstr "O almacenamento borrado, cómpre reiniciar a aplicación agora."
 
 #: src/Navigation.tsx:240
 #: src/view/screens/Settings/index.tsx:830
 msgid "Storybook"
-msgstr ""
+msgstr "Libro de contos"
 
 #: src/components/moderation/LabelsOnMeDialog.tsx:299
 #: src/components/moderation/LabelsOnMeDialog.tsx:300
@@ -6972,44 +6319,35 @@ msgstr "Enviar"
 
 #: src/view/screens/ProfileList.tsx:703
 msgid "Subscribe"
-msgstr "Subscribirse"
+msgstr "Suscribirse"
 
 #: src/screens/Profile/Sections/Labels.tsx:201
 msgid "Subscribe to @{0} to use these labels:"
-msgstr "Subscribirse a @{0} para usar estas etiquetas:"
+msgstr "Suscríbete a @{0} para usar estas etiquetas:"
 
 #: src/screens/Profile/Header/ProfileHeaderLabeler.tsx:228
 msgid "Subscribe to Labeler"
-msgstr "Subscribirse ao etiquetador"
-
-#: src/screens/Onboarding/StepAlgoFeeds/FeedCard.tsx:172
-#: src/screens/Onboarding/StepAlgoFeeds/FeedCard.tsx:307
-#~ msgid "Subscribe to the {0} feed"
-#~ msgstr "Subscribirse á fonte {0}"
+msgstr "Suscribirse ao etiquetador"
 
 #: src/screens/Profile/Header/ProfileHeaderLabeler.tsx:194
 msgid "Subscribe to this labeler"
-msgstr "Subscribirse a este etiquetador"
+msgstr "Suscribirse a este etiquetador"
 
 #: src/view/screens/ProfileList.tsx:699
 msgid "Subscribe to this list"
-msgstr "Subscribirse a esta lista"
+msgstr "Suscribirse a esta listaxe"
 
 #: src/components/dialogs/VerifyEmailDialog.tsx:81
 msgid "Success!"
-msgstr ""
+msgstr "Éxito!"
 
 #: src/view/screens/Search/Explore.tsx:332
 msgid "Suggested accounts"
 msgstr "Contas suxeridas"
 
-#: src/view/screens/Search/Search.tsx:425
-#~ msgid "Suggested Follows"
-#~ msgstr "Usuarios suxeridos para seguir"
-
 #: src/components/FeedInterstitials.tsx:318
 msgid "Suggested for you"
-msgstr "Suxestións para ti"
+msgstr "Suxerido para ti"
 
 #: src/view/com/composer/labels/LabelsBtn.tsx:146
 #: src/view/com/composer/labels/LabelsBtn.tsx:149
@@ -7025,19 +6363,15 @@ msgstr "Soporte"
 #: src/components/dialogs/SwitchAccount.tsx:46
 #: src/components/dialogs/SwitchAccount.tsx:49
 msgid "Switch Account"
-msgstr "Trocar Conta"
-
-#: src/tours/HomeTour.tsx:48
-#~ msgid "Switch between feeds to control your experience."
-#~ msgstr "Troca entre fontes para controlar a túa experiencia."
+msgstr "Cambiar a outra conta"
 
 #: src/view/screens/Settings/index.tsx:131
 msgid "Switch to {0}"
-msgstr "Trocar para {0}"
+msgstr "Cambiar a {0}"
 
 #: src/view/screens/Settings/index.tsx:132
 msgid "Switches the account you are logged in to"
-msgstr "Muda a conta coa que estás conectado para"
+msgstr "Cambia a conta na que iniciaches sesión"
 
 #: src/components/dialogs/nuxs/NeueTypography.tsx:78
 #: src/screens/Settings/AppearanceSettings.tsx:101
@@ -7047,11 +6381,7 @@ msgstr "Sistema"
 
 #: src/view/screens/Settings/index.tsx:818
 msgid "System log"
-msgstr "Rexisto do sistema"
-
-#: src/components/dialogs/MutedWords.tsx:323
-#~ msgid "tag"
-#~ msgstr "etiqueta"
+msgstr "Rexistro do sistema"
 
 #: src/components/TagMenu/index.tsx:87
 msgid "Tag menu: {displayTag}"
@@ -7061,42 +6391,34 @@ msgstr "Menú de etiquetas: {displayTag}"
 msgid "Tags only"
 msgstr "Só etiquetas"
 
-#: src/view/com/modals/crop-image/CropImage.web.tsx:135
-#~ msgid "Tall"
-#~ msgstr "Alto"
-
 #: src/components/ProgressGuide/Toast.tsx:150
 msgid "Tap to dismiss"
-msgstr "Tocar para rexeitar"
+msgstr "Toca para descartar"
 
 #: src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerNative.tsx:136
 msgid "Tap to enter full screen"
-msgstr "Tocar para pantalla completa"
+msgstr "Toca para abrir a pantalla completa"
 
 #: src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerNative.tsx:142
 msgid "Tap to play or pause"
-msgstr "Tocar para reproducir ou por en pausa"
+msgstr "Toca para reproducir ou pausar"
 
 #: src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerNative.tsx:159
 msgid "Tap to toggle sound"
-msgstr "Tocar para alternar o son"
+msgstr "Toca para alternar o son"
 
 #: src/view/com/util/images/AutoSizedImage.tsx:219
 #: src/view/com/util/images/AutoSizedImage.tsx:239
 msgid "Tap to view full image"
-msgstr "Tocar para ver a imaxe completa"
-
-#: src/view/com/util/images/AutoSizedImage.tsx:70
-#~ msgid "Tap to view fully"
-#~ msgstr "Tocar para ver completa"
+msgstr "Toca para ver a imaxe completa"
 
 #: src/state/shell/progress-guide.tsx:166
 msgid "Task complete - 10 likes!"
-msgstr "Tarefa acadada - 10 gústame!"
+msgstr "Tarefa completada - 10 gústame!"
 
 #: src/components/ProgressGuide/List.tsx:49
 msgid "Teach our algorithm what you like"
-msgstr "Apréndelle ao noso algoritmo o que che gusta"
+msgstr "Ensínalle ao noso algoritmo o que che gusta"
 
 #: src/screens/Onboarding/index.tsx:36
 #: src/screens/Onboarding/state.ts:101
@@ -7109,19 +6431,15 @@ msgstr "Conta unha brincadeira!"
 
 #: src/screens/Profile/Header/EditProfileDialog.tsx:352
 msgid "Tell us a bit about yourself"
-msgstr "Fálanos un pouco sobre ti"
+msgstr "Fálanos un pouco de ti"
 
 #: src/screens/StarterPack/Wizard/StepDetails.tsx:63
 msgid "Tell us a little more"
 msgstr "Cóntanos un pouco máis"
 
-#: src/components/dialogs/nuxs/TenMillion/index.tsx:518
-#~ msgid "Ten Million"
-#~ msgstr "Dez Millóns"
-
 #: src/view/shell/desktop/RightNav.tsx:90
 msgid "Terms"
-msgstr "Termos"
+msgstr "Condicións"
 
 #: src/Navigation.tsx:270
 #: src/view/screens/Settings/index.tsx:906
@@ -7129,18 +6447,14 @@ msgstr "Termos"
 #: src/view/shell/Drawer.tsx:284
 #: src/view/shell/Drawer.tsx:286
 msgid "Terms of Service"
-msgstr "Termos de Servizo"
+msgstr "Condicións de servizo"
 
 #: src/lib/moderation/useReportOptions.ts:60
 #: src/lib/moderation/useReportOptions.ts:99
 #: src/lib/moderation/useReportOptions.ts:107
 #: src/lib/moderation/useReportOptions.ts:115
 msgid "Terms used violate community standards"
-msgstr "Os termos empregados violan as normas da comunidade"
-
-#: src/components/dialogs/MutedWords.tsx:323
-#~ msgid "text"
-#~ msgstr "texto"
+msgstr "Os termos utilizados infrinxen os estándares da comunidade"
 
 #: src/components/dialogs/MutedWords.tsx:266
 msgid "Text & tags"
@@ -7153,32 +6467,28 @@ msgstr "Campo de entrada de texto"
 
 #: src/components/dialogs/VerifyEmailDialog.tsx:82
 msgid "Thank you! Your email has been successfully verified."
-msgstr "Grazas! O teu correo foi verificado con éxito."
+msgstr "Grazas! Verificouse correctamente o teu correo electrónico."
 
 #: src/components/dms/ReportDialog.tsx:129
 #: src/components/ReportDialog/SubmitView.tsx:82
 msgid "Thank you. Your report has been sent."
-msgstr "Grazas. A túa denuncia foi enviada."
-
-#: src/components/dialogs/nuxs/TenMillion/index.tsx:593
-#~ msgid "Thanks for being one of our first 10 million users."
-#~ msgstr "Grazas por sere un dos nosos primeiros 10 millóns de usuarios."
-
-#: src/components/intents/VerifyEmailIntentDialog.tsx:74
-#~ msgid "Thanks, you have successfully verified your email address."
-#~ msgstr "Grazas, verificaches o teu enderezo de correo electrónico con éxito."
+msgstr "Grazas. O teu informe foi enviado."
 
 #: src/components/intents/VerifyEmailIntentDialog.tsx:82
-msgid "Thanks, you have successfully verified your email address. You can close this dialog."
-msgstr "Grazas, verificaches o teu correo con éxito. Podes pechar este diálogo."
+msgid ""
+"Thanks, you have successfully verified your email address. You can close "
+"this dialog."
+msgstr ""
+"Grazas, verificaches correctamente o teu enderezo de correo electrónico. "
+"Podes pechar esta xanela."
 
 #: src/view/com/modals/ChangeHandle.tsx:452
 msgid "That contains the following:"
-msgstr "Isto contén o seguinte:"
+msgstr "Que contén o seguinte:"
 
 #: src/screens/Signup/StepHandle.tsx:51
 msgid "That handle is already taken."
-msgstr "Este nome de usuario xa está collido."
+msgstr "Ese alcume xa está en uso."
 
 #: src/screens/StarterPack/StarterPackScreen.tsx:103
 #: src/screens/StarterPack/StarterPackScreen.tsx:104
@@ -7187,188 +6497,195 @@ msgstr "Este nome de usuario xa está collido."
 #: src/screens/StarterPack/Wizard/index.tsx:107
 #: src/screens/StarterPack/Wizard/index.tsx:117
 msgid "That starter pack could not be found."
-msgstr "Non foi posíbel atopar este paquete de inicio."
+msgstr "Non se puido atopar ese paquete de inicio."
 
 #: src/view/com/post-thread/PostQuotes.tsx:133
 msgid "That's all, folks!"
-msgstr "Iso é todo, amigos!"
+msgstr "Iso é todo, parroquia!"
 
 #: src/screens/Profile/Header/ProfileHeaderStandard.tsx:269
 #: src/view/com/profile/ProfileMenu.tsx:329
 msgid "The account will be able to interact with you after unblocking."
 msgstr "A conta poderá interactuar contigo despois de desbloqueala."
 
-#: src/components/moderation/ModerationDetailsDialog.tsx:127
-#~ msgid "the author"
-#~ msgstr "o autor"
-
 #: src/components/moderation/ModerationDetailsDialog.tsx:118
 #: src/lib/moderation/useModerationCauseDescription.ts:126
 msgid "The author of this thread has hidden this reply."
-msgstr ""
+msgstr "A persoa autora deste fío ocultou esta resposta."
 
 #: src/screens/Moderation/index.tsx:369
 msgid "The Bluesky web application"
-msgstr "A aplicación web do Bluesky"
+msgstr "A aplicación web de Bluesky"
 
 #: src/view/screens/CommunityGuidelines.tsx:38
 msgid "The Community Guidelines have been moved to <0/>"
-msgstr ""
+msgstr "As Directrices da Comunidade movéronse a <0/>"
 
 #: src/view/screens/CopyrightPolicy.tsx:35
 msgid "The Copyright Policy has been moved to <0/>"
-msgstr "A Política de Copyright foi movida para <0/>"
+msgstr "A Política de Copyright moveuse a <0/>"
 
 #: src/view/com/posts/FeedShutdownMsg.tsx:102
 msgid "The Discover feed"
-msgstr ""
+msgstr "A canle de Descubrir"
 
 #: src/state/shell/progress-guide.tsx:167
 #: src/state/shell/progress-guide.tsx:172
 msgid "The Discover feed now knows what you like"
-msgstr ""
+msgstr "A canle Discover agora sabe o que che gusta"
 
 #: src/screens/StarterPack/StarterPackLandingScreen.tsx:320
-msgid "The experience is better in the app. Download Bluesky now and we'll pick back up where you left off."
-msgstr "A experiencia é mellor na aplicación. Descarga Bluesky agora e comezaremos dende o deixaches."
+msgid ""
+"The experience is better in the app. Download Bluesky now and we'll pick "
+"back up where you left off."
+msgstr ""
+"A experiencia é mellor na aplicación. Descarga Bluesky agora e retomarémolo "
+"onde o deixaches."
 
 #: src/view/com/posts/FeedShutdownMsg.tsx:67
 msgid "The feed has been replaced with Discover."
-msgstr ""
+msgstr "A canle foi substituída por Descubrir."
 
 #: src/components/moderation/LabelsOnMeDialog.tsx:58
 msgid "The following labels were applied to your account."
-msgstr "As seguintes etiquetas foron aplicadas a túa conta."
+msgstr "Aplicáronse as seguintes etiquetas á túa conta."
 
 #: src/components/moderation/LabelsOnMeDialog.tsx:59
 msgid "The following labels were applied to your content."
-msgstr "As seguintes etiquetas foron aplicadas ao teu contido."
+msgstr "Aplicáronse as seguintes etiquetas ao teu contido."
 
 #: src/screens/Onboarding/Layout.tsx:58
 msgid "The following steps will help customize your Bluesky experience."
-msgstr "Os seguintes pasos axudaranche a personalizar a túa experiencia no Bluesky."
+msgstr "Os seguintes pasos axudarán a personalizar a túa experiencia Bluesky."
 
 #: src/view/com/post-thread/PostThread.tsx:208
 #: src/view/com/post-thread/PostThread.tsx:220
 msgid "The post may have been deleted."
-msgstr "A publicación puido ser eliminada."
+msgstr "É posíbel que se eliminase o chío."
 
 #: src/view/screens/PrivacyPolicy.tsx:35
 msgid "The Privacy Policy has been moved to <0/>"
-msgstr "A Política de Privacidade foi movida para <0/>"
+msgstr "A Política de Privacidade moveuse a <0/>"
 
 #: src/view/com/composer/state/video.ts:409
 msgid "The selected video is larger than 50MB."
-msgstr "O vídeo seleccionado é maior a 50MB."
+msgstr "O vídeo seleccionado pesa máis de 50 MB."
 
 #: src/screens/StarterPack/StarterPackScreen.tsx:724
-msgid "The starter pack that you are trying to view is invalid. You may delete this starter pack instead."
+msgid ""
+"The starter pack that you are trying to view is invalid. You may delete "
+"this starter pack instead."
 msgstr ""
+"O paquete de inicio que estás tentando ver non é válido. Podes eliminar "
+"este paquete de inicio no seu lugar."
 
 #: src/view/screens/Support.tsx:37
-msgid "The support form has been moved. If you need help, please <0/> or visit {HELP_DESK_URL} to get in touch with us."
+msgid ""
+"The support form has been moved. If you need help, please <0/> or visit "
+"{HELP_DESK_URL} to get in touch with us."
 msgstr ""
+"Moveuse o formulario de soporte. Se necesitas axuda, por favor <0/> ou "
+"visita {HELP_DESK_URL} para poñerte en contacto connosco."
 
 #: src/view/screens/TermsOfService.tsx:35
 msgid "The Terms of Service have been moved to"
-msgstr "Os Termos de Servizo foron movidos para"
+msgstr "Movéronse as Condicións de Servizo a"
 
 #: src/components/intents/VerifyEmailIntentDialog.tsx:94
-msgid "The verification code you have provided is invalid. Please make sure that you have used the correct verification link or request a new one."
+msgid ""
+"The verification code you have provided is invalid. Please make sure that "
+"you have used the correct verification link or request a new one."
 msgstr ""
+"O código de verificación que proporcionaches non é válido. Asegúrate de "
+"utilizar a ligazón de verificación correcta ou solicita unha nova."
 
 #: src/components/dialogs/nuxs/NeueTypography.tsx:82
 #: src/screens/Settings/AppearanceSettings.tsx:152
 msgid "Theme"
 msgstr "Tema"
 
-#: src/screens/Onboarding/StepAlgoFeeds/index.tsx:141
-#~ msgid "There are many feeds to try:"
-#~ msgstr "Hai máis fontes que probar:"
-
 #: src/screens/Settings/components/DeactivateAccountDialog.tsx:86
 msgid "There is no time limit for account deactivation, come back any time."
-msgstr "Non hai límite de tempo para deshabilitar a conta, volve cando queiras."
-
-#: src/screens/Profile/Header/ProfileHeaderLabeler.tsx:112
-#: src/view/screens/ProfileFeed.tsx:539
-#~ msgid "There was an an issue contacting the server, please check your internet connection and try again."
-#~ msgstr "Produciuse un problema ao conectar co servidor, por favor verifica a túa conexión a internet e téntao de novo."
-
-#: src/view/com/posts/FeedErrorMessage.tsx:145
-#~ msgid "There was an an issue removing this feed. Please check your internet connection and try again."
-#~ msgstr "Produciuse un problema ao eliminar esta fonte. Por favor, verifica a túa conexión a internet e téntao de novo."
-
-#: src/view/com/posts/FeedShutdownMsg.tsx:52
-#: src/view/com/posts/FeedShutdownMsg.tsx:71
-#: src/view/screens/ProfileFeed.tsx:204
-#~ msgid "There was an an issue updating your feeds, please check your internet connection and try again."
-#~ msgstr "Produciuse un problema ao actualizar as túas fontes. Por favor, verifica a túa conexión a internet e téntao de novo."
+msgstr ""
+"Non hai límite de tempo para a desactivación da conta, regresa en calquera "
+"momento."
 
 #: src/components/dialogs/GifSelect.tsx:225
 msgid "There was an issue connecting to Tenor."
-msgstr "Produciuse un problema conectando co Tenor."
-
-#: src/screens/Messages/Conversation/MessageListError.tsx:23
-#~ msgid "There was an issue connecting to the chat."
-#~ msgstr "Produciuse un problema ao conectar á conversa."
+msgstr "Houbo un problema ao conectarse a Tenor."
 
 #: src/view/screens/ProfileFeed.tsx:240
 #: src/view/screens/ProfileList.tsx:369
 #: src/view/screens/ProfileList.tsx:388
 #: src/view/screens/SavedFeeds.tsx:86
 msgid "There was an issue contacting the server"
-msgstr "Produciuse un problema conectando co servidor"
+msgstr "Produciuse un problema ao contactar co servidor"
 
 #: src/screens/Profile/Header/ProfileHeaderLabeler.tsx:111
 #: src/view/screens/ProfileFeed.tsx:546
-msgid "There was an issue contacting the server, please check your internet connection and try again."
-msgstr "Produciuse un problema conectando co servidor, verifica a conexión a internet e téntao de novo."
+msgid ""
+"There was an issue contacting the server, please check your internet "
+"connection and try again."
+msgstr ""
+"Houbo un problema ao contactar co servidor. Comproba a túa conexión a "
+"Internet e téntao de novo."
 
 #: src/view/com/feeds/FeedSourceCard.tsx:127
 #: src/view/com/feeds/FeedSourceCard.tsx:140
 msgid "There was an issue contacting your server"
-msgstr "Produciuse un problema conectando co teu servidor"
+msgstr "Produciuse un problema ao contactar co teu servidor"
 
 #: src/view/com/notifications/Feed.tsx:129
 msgid "There was an issue fetching notifications. Tap here to try again."
-msgstr "Produciuse un problema obtendo as notificacións. Preme aquí para tentar de novo."
+msgstr ""
+"Houbo un problema ao recuperar as notificacións. Toca aquí para tentalo de "
+"novo."
 
 #: src/view/com/posts/Feed.tsx:473
 msgid "There was an issue fetching posts. Tap here to try again."
-msgstr "Produciuse un problema obtendo as publicacións. Preme aquí para tentar de novo."
+msgstr "Houbo un problema ao recuperar os chíos. Toca aquí para tentalo de novo."
 
 #: src/view/com/lists/ListMembers.tsx:169
 msgid "There was an issue fetching the list. Tap here to try again."
-msgstr "Produciuse un problema obtendo a lista. Preme aquí para tentar de novo."
+msgstr "Houbo un problema ao buscar a listaxe. Toca aquí para tentalo de novo."
 
 #: src/view/com/feeds/ProfileFeedgens.tsx:150
 #: src/view/com/lists/ProfileLists.tsx:149
 msgid "There was an issue fetching your lists. Tap here to try again."
-msgstr "Produciuse un problema obtendo as túas listas. Preme aquí para tentar de novo."
+msgstr ""
+"Houbo un problema ao recuperar as túas listaxes. Toca aquí para tentalo de "
+"novo."
 
 #: src/view/com/posts/FeedErrorMessage.tsx:145
-msgid "There was an issue removing this feed. Please check your internet connection and try again."
-msgstr "Produciuse un problema ao eliminar esta fonte. Verifica a conexión a internet e téntao de novo."
+msgid ""
+"There was an issue removing this feed. Please check your internet "
+"connection and try again."
+msgstr ""
+"Produciuse un problema ao eliminar esta canle. Comproba a túa conexión a "
+"Internet e téntao de novo."
 
 #: src/components/dms/ReportDialog.tsx:217
 #: src/components/ReportDialog/SubmitView.tsx:87
-msgid "There was an issue sending your report. Please check your internet connection."
-msgstr "Produciuse un problema enviando a túa denuncia. Verifica a conexión a internet e téntao de novo."
-
-#: src/screens/Onboarding/StepModeration/AdultContentEnabledPref.tsx:65
-#~ msgid "There was an issue syncing your preferences with the server"
-#~ msgstr "Produciuse un problema ao sincronizar as túas preferencias co servidor"
+msgid ""
+"There was an issue sending your report. Please check your internet "
+"connection."
+msgstr ""
+"Houbo un problema ao enviar o teu informe. Comproba a túa conexión a "
+"internet."
 
 #: src/view/com/posts/FeedShutdownMsg.tsx:52
 #: src/view/com/posts/FeedShutdownMsg.tsx:71
 #: src/view/screens/ProfileFeed.tsx:211
-msgid "There was an issue updating your feeds, please check your internet connection and try again."
-msgstr "Produciuse un problema actualizando as túas fontes. Verifica a conexión a internet e téntao de novo."
+msgid ""
+"There was an issue updating your feeds, please check your internet "
+"connection and try again."
+msgstr ""
+"Houbo un problema ao actualizar as túas canles. Comproba a túa conexión a "
+"Internet e téntao de novo."
 
 #: src/view/screens/AppPasswords.tsx:75
 msgid "There was an issue with fetching your app passwords"
-msgstr "Produciuse un problema ao obter o contrasinal da aplicación"
+msgstr "Houbo un problema ao obter os contrasinais das túas aplicacións"
 
 #: src/screens/Profile/Header/ProfileHeaderStandard.tsx:97
 #: src/screens/Profile/Header/ProfileHeaderStandard.tsx:118
@@ -7382,7 +6699,7 @@ msgstr "Produciuse un problema ao obter o contrasinal da aplicación"
 #: src/view/com/profile/ProfileMenu.tsx:149
 #: src/view/com/profile/ProfileMenu.tsx:161
 msgid "There was an issue! {0}"
-msgstr "Produciuse un problema! {0}"
+msgstr "Houbo un problema! {0}"
 
 #: src/components/dialogs/PostInteractionSettingsDialog.tsx:182
 #: src/screens/List/ListHiddenScreen.tsx:63
@@ -7393,20 +6710,22 @@ msgstr "Produciuse un problema! {0}"
 #: src/view/screens/ProfileList.tsx:426
 #: src/view/screens/ProfileList.tsx:439
 msgid "There was an issue. Please check your internet connection and try again."
-msgstr "Produciuse un problema. Por favor, comproba a túa conexión a internet e téntao de novo."
+msgstr "Houbo un problema. Comproba a túa conexión a Internet e téntao de novo."
 
 #: src/components/dialogs/GifSelect.tsx:271
 #: src/view/com/util/ErrorBoundary.tsx:59
-msgid "There was an unexpected issue in the application. Please let us know if this happened to you!"
-msgstr "Produciuse un problema inesperado na aplicación. Por favor, fainos saber se che pasou a ti!"
+msgid ""
+"There was an unexpected issue in the application. Please let us know if "
+"this happened to you!"
+msgstr "Houbo un problema inesperado na aplicación. Avísanos se che pasou isto!"
 
 #: src/screens/SignupQueued.tsx:112
-msgid "There's been a rush of new users to Bluesky! We'll activate your account as soon as we can."
-msgstr "Produciuse unha grande afluencia de novos usuarios no Bluesky! Activaremos a túa conta o máis axiña posíbel."
-
-#: src/screens/Onboarding/StepSuggestedAccounts/index.tsx:146
-#~ msgid "These are popular accounts you might like:"
-#~ msgstr "Estas son contas populares que che poden gustar:"
+msgid ""
+"There's been a rush of new users to Bluesky! We'll activate your account as "
+"soon as we can."
+msgstr ""
+"Houbo un alude de novas persoas a Bluesky! Activaremos a túa conta en canto "
+"poidamos."
 
 #: src/components/moderation/ScreenHider.tsx:111
 msgid "This {screenDescription} has been flagged:"
@@ -7414,96 +6733,106 @@ msgstr "Esta {screenDescription} foi marcada:"
 
 #: src/components/moderation/ScreenHider.tsx:106
 msgid "This account has requested that users sign in to view their profile."
-msgstr "Esta conta solicitou que os usuarios inicien sesión para ver o seu perfil."
+msgstr "Esta conta solicitou que as persoas inicien sesión para ver o seu perfil."
 
 #: src/components/dms/BlockedByListDialog.tsx:34
-msgid "This account is blocked by one or more of your moderation lists. To unblock, please visit the lists directly and remove this user."
-msgstr "Esta conta está bloqueada por unha ou máis das túas listas de moderación. Para desbloqueala, por favor vai directamente ás listas e elimina este usuario."
-
-#: src/components/moderation/LabelsOnMeDialog.tsx:260
-#~ msgid "This appeal will be sent to <0>{0}</0>."
-#~ msgstr "Esta apelación será enviada a <0>{0}</0>."
+msgid ""
+"This account is blocked by one or more of your moderation lists. To "
+"unblock, please visit the lists directly and remove this user."
+msgstr ""
+"Esta conta está bloqueada por unha ou máis das túas listaxes de moderación. "
+"Para desbloquear, visita as listaxes directamente e elimina esta persoa."
 
 #: src/components/moderation/LabelsOnMeDialog.tsx:246
 msgid "This appeal will be sent to <0>{sourceName}</0>."
-msgstr "Esta apelación será enviada a <0>{sourceName}</0>."
+msgstr "Esta apelación enviarase a <0>{sourceName}</0>."
 
 #: src/screens/Messages/components/ChatDisabled.tsx:104
 msgid "This appeal will be sent to Bluesky's moderation service."
-msgstr "Esta apelación será enviada ao servizo de moderación do Bluesky."
+msgstr "Esta apelación enviarase ao servizo de moderación de Bluesky."
 
 #: src/screens/Messages/components/MessageListError.tsx:18
 msgid "This chat was disconnected"
-msgstr "Esta conversa foi desconectada"
-
-#: src/screens/Messages/Conversation/MessageListError.tsx:26
-#~ msgid "This chat was disconnected due to a network error."
-#~ msgstr "Esta conversa foi desconectada por mor dun erro de rede."
+msgstr "Desconectouse este conversa"
 
 #: src/lib/moderation/useGlobalLabelStrings.ts:19
 msgid "This content has been hidden by the moderators."
-msgstr "Este contido foi ocultado polos moderadores."
+msgstr "Este contido ocultouse por decisión dos moderadores."
 
 #: src/lib/moderation/useGlobalLabelStrings.ts:24
 msgid "This content has received a general warning from moderators."
-msgstr "Este contido recibiu un aviso xeral dos moderadores."
+msgstr "Este contido recibiu unha advertencia xeral dos moderadores."
 
 #: src/components/dialogs/EmbedConsent.tsx:63
 msgid "This content is hosted by {0}. Do you want to enable external media?"
-msgstr "Este contido está hospedado por {0}. Desexas habilitar os medios externos?"
+msgstr "Este contido está aloxado por {0}. Queres activar medios externos?"
 
 #: src/components/moderation/ModerationDetailsDialog.tsx:83
 #: src/lib/moderation/useModerationCauseDescription.ts:82
-msgid "This content is not available because one of the users involved has blocked the other."
-msgstr "Este contido non está dispoñíbel xa que un dos usuarios involucrados bloqueou ao outro."
+msgid ""
+"This content is not available because one of the users involved has blocked "
+"the other."
+msgstr ""
+"Este contido non está dispoñíbel porque unha das persoas implicadas "
+"bloqueou a outra."
 
 #: src/view/com/posts/FeedErrorMessage.tsx:114
 msgid "This content is not viewable without a Bluesky account."
-msgstr "Este contido non é visíbel sen unha conta do Bluesky."
+msgstr "Este contido non se pode ver sen unha conta Bluesky."
 
 #: src/screens/Messages/components/ChatListItem.tsx:266
-msgid "This conversation is with a deleted or a deactivated account. Press for options."
-msgstr "Esta conversa é cunha conta eliminada ou deshabilitada. Premer para ver as opcións."
+msgid ""
+"This conversation is with a deleted or a deactivated account. Press for "
+"options."
+msgstr ""
+"Esta conversa é cunha conta eliminada ou desactivada. Preme para ver as "
+"opcións."
 
 #: src/view/screens/Settings/ExportCarDialog.tsx:92
-msgid "This feature is in beta. You can read more about repository exports in <0>this blogpost</0>."
-msgstr "Esta funcionailidade está en fase beta. Podes saber máis sobre a exportación de repositorios nesta <0>publicación no blog</0>."
+msgid ""
+"This feature is in beta. You can read more about repository exports in "
+"<0>this blogpost</0>."
+msgstr ""
+"Esta función está en versión beta. Podes ler máis sobre as exportacións de "
+"repositorios en <0>este blog</0>."
 
 #: src/view/com/posts/FeedErrorMessage.tsx:120
-msgid "This feed is currently receiving high traffic and is temporarily unavailable. Please try again later."
-msgstr "Esta fonte está a recibir moito tráfico e non está dispoñíbel temporalmente. Téntao máis tarde."
-
-#: src/screens/Profile/Sections/Feed.tsx:59
-#: src/view/screens/ProfileFeed.tsx:471
-#: src/view/screens/ProfileList.tsx:729
-#~ msgid "This feed is empty!"
-#~ msgstr "Esta fonte está baleira!"
+msgid ""
+"This feed is currently receiving high traffic and is temporarily "
+"unavailable. Please try again later."
+msgstr ""
+"Esta canle está a recibir moito tráfico e non está dispoñíbel "
+"temporalmente. Téntao de novo máis tarde."
 
 #: src/view/com/posts/CustomFeedEmptyState.tsx:37
-msgid "This feed is empty! You may need to follow more users or tune your language settings."
-msgstr "Esta fonte está baleira! É posíbel que precises seguir máis usuarios ou axustar os axustes de lingua."
+msgid ""
+"This feed is empty! You may need to follow more users or tune your language "
+"settings."
+msgstr ""
+"Esta canle está baleira! É posíbel que teñas que seguir a máis persoas ou "
+"axustar a túa configuración de idioma."
 
 #: src/components/StarterPack/Main/PostsList.tsx:36
 #: src/view/screens/ProfileFeed.tsx:478
 #: src/view/screens/ProfileList.tsx:788
 msgid "This feed is empty."
-msgstr "A fonte está baleira."
+msgstr "Esta canle está baleira."
 
 #: src/view/com/posts/FeedShutdownMsg.tsx:99
 msgid "This feed is no longer online. We are showing <0>Discover</0> instead."
-msgstr "Esta fonte xa non está en liña. Amosaremos <0>Descubrir</0> no seu lugar."
+msgstr "Esta canle xa non está en liña. No seu lugar, mostramos <0>Descubrir</0>."
 
 #: src/components/dialogs/BirthDateSettings.tsx:40
 msgid "This information is not shared with other users."
-msgstr "Esta información non está compartida con outros usuarios."
+msgstr "Esta información non se comparte con outras persoas."
 
 #: src/view/com/modals/VerifyEmail.tsx:127
-msgid "This is important in case you ever need to change your email or reset your password."
-msgstr "Isto é importante no caso de que algunha vez precises mudar o teu correo ou restablecer o contrasinal."
-
-#: src/components/moderation/ModerationDetailsDialog.tsx:124
-#~ msgid "This label was applied by {0}."
-#~ msgstr "Esta etiqueta foi aplicada por {0}."
+msgid ""
+"This is important in case you ever need to change your email or reset your "
+"password."
+msgstr ""
+"Isto é importante no caso de que necesites cambiar o teu correo electrónico "
+"ou restablecer o teu contrasinal."
 
 #: src/components/moderation/ModerationDetailsDialog.tsx:151
 msgid "This label was applied by <0>{0}</0>."
@@ -7511,35 +6840,43 @@ msgstr "Esta etiqueta foi aplicada por <0>{0}</0>."
 
 #: src/components/moderation/ModerationDetailsDialog.tsx:146
 msgid "This label was applied by the author."
-msgstr "Esta etiqueta foi aplicada polo autor."
-
-#: src/components/moderation/LabelsOnMeDialog.tsx:165
-#~ msgid "This label was applied by you"
-#~ msgstr "Esta etiqueta foi aplicada por ti"
+msgstr "Esta etiqueta foi aplicada pola persoa autora."
 
 #: src/components/moderation/LabelsOnMeDialog.tsx:163
 msgid "This label was applied by you."
 msgstr "Esta etiqueta foi aplicada por ti."
 
 #: src/screens/Profile/Sections/Labels.tsx:188
-msgid "This labeler hasn't declared what labels it publishes, and may not be active."
-msgstr "Este etiquetador non declarou que etiquetas publicou, e pode que non estea activo."
+msgid ""
+"This labeler hasn't declared what labels it publishes, and may not be "
+"active."
+msgstr ""
+"Este etiquetador non declarou que etiquetas publica e é posíbel que non "
+"estea activo."
 
 #: src/view/com/modals/LinkWarning.tsx:72
 msgid "This link is taking you to the following website:"
-msgstr "Está ligazón lévache ao seguinte sitio web:"
+msgstr "Esta ligazón lévate ao seguinte sitio web:"
 
 #: src/screens/List/ListHiddenScreen.tsx:136
-msgid "This list - created by <0>{0}</0> - contains possible violations of Bluesky's community guidelines in its name or description."
-msgstr "Esta lista - creada por <0>{0}</0> - contén posíbeis violacións das directrices da comunidade do Bluesky no seu nome ou na descrición."
+msgid ""
+"This list - created by <0>{0}</0> - contains possible violations of "
+"Bluesky's community guidelines in its name or description."
+msgstr ""
+"Esta listaxe, creada por <0>{0}</0>, contén posíbeis infraccións das "
+"directrices da comunidade de Bluesky no seu nome ou descrición."
 
 #: src/view/screens/ProfileList.tsx:966
 msgid "This list is empty!"
-msgstr "Esta lista está baleira!"
+msgstr "Esta listaxe está baleira!"
 
 #: src/screens/Profile/ErrorState.tsx:40
-msgid "This moderation service is unavailable. See below for more details. If this issue persists, contact us."
-msgstr "Este servizo de moderación non está dispoñíbel. Máis detalles a continuación. Se o problema persiste, contacta connosco."
+msgid ""
+"This moderation service is unavailable. See below for more details. If this "
+"issue persists, contact us."
+msgstr ""
+"Este servizo de moderación non está disponíbel. Consulta máis detalles a "
+"continuación. Se o problema persiste, contáctanos."
 
 #: src/view/com/modals/AddAppPasswords.tsx:110
 msgid "This name is already in use"
@@ -7547,93 +6884,109 @@ msgstr "Este nome xa está en uso"
 
 #: src/view/com/post-thread/PostThreadItem.tsx:139
 msgid "This post has been deleted."
-msgstr "Esta publicación foi eliminada."
+msgstr "Este chío foi eliminado."
 
 #: src/view/com/util/forms/PostDropdownBtn.tsx:700
 #: src/view/com/util/post-ctrls/PostCtrls.tsx:346
-msgid "This post is only visible to logged-in users. It won't be visible to people who aren't logged in."
-msgstr "Esta publicación só é visíbel para os usuarios conectados. Non será visíbel para as persoas desconectadas."
+msgid ""
+"This post is only visible to logged-in users. It won't be visible to people "
+"who aren't logged in."
+msgstr ""
+"Esta publicación só é visíbel para as persoas que iniciaron sesión. Non "
+"será visíbel para as persoas que non estean iniciadas."
 
 #: src/view/com/util/forms/PostDropdownBtn.tsx:681
 msgid "This post will be hidden from feeds and threads. This cannot be undone."
-msgstr "Esta publicación ocultarase nas fontes e fíos. Isto non se pode desfacer."
-
-#: src/view/com/util/forms/PostDropdownBtn.tsx:443
-#~ msgid "This post will be hidden from feeds."
-#~ msgstr "Esta publicación ocultarase nas fontes."
+msgstr "Este chío ocultarase das canles e dos fíos. Isto non se pode desfacer."
 
 #: src/view/com/composer/Composer.tsx:364
 msgid "This post's author has disabled quote posts."
-msgstr ""
+msgstr "A persoa autora deste chío desactivou os chíos de citas."
 
 #: src/view/com/profile/ProfileMenu.tsx:350
-msgid "This profile is only visible to logged-in users. It won't be visible to people who aren't logged in."
-msgstr "Este perfil só é visíbel para os usuarios conectados. Non será visíbel para as persoas desconectadas."
+msgid ""
+"This profile is only visible to logged-in users. It won't be visible to "
+"people who aren't logged in."
+msgstr ""
+"Este perfil só é visíbel para as persoas que iniciaron sesión. Non será "
+"visíbel para as persoas que non estean iniciadas."
 
 #: src/view/com/util/forms/PostDropdownBtn.tsx:743
-msgid "This reply will be sorted into a hidden section at the bottom of your thread and will mute notifications for subsequent replies - both for yourself and others."
-msgstr "Esta resposta será clasificada nunha sección oculta ao final do teu fío e silenciará as notificacións para as respostas posteriores - tanto para ti coma para outros."
+msgid ""
+"This reply will be sorted into a hidden section at the bottom of your "
+"thread and will mute notifications for subsequent replies - both for "
+"yourself and others."
+msgstr ""
+"Esta resposta ordenarase nunha sección oculta na parte inferior do teu fío "
+"e silenciará as notificacións para as respostas posteriores, tanto para ti "
+"como para os demais."
 
 #: src/screens/Signup/StepInfo/Policies.tsx:37
 msgid "This service has not provided terms of service or a privacy policy."
-msgstr "Este servizo non forneceu termos do servizo ou política de privacidade."
+msgstr ""
+"Este servizo non proporcionou condicións de servizo nin unha política de "
+"privacidade."
 
 #: src/view/com/modals/ChangeHandle.tsx:432
 msgid "This should create a domain record at:"
-msgstr "Isto debería crear un rexisto de dominio en:"
+msgstr "Isto debería crear un rexistro de dominio en:"
 
 #: src/view/com/profile/ProfileFollowers.tsx:96
 msgid "This user doesn't have any followers."
-msgstr "Este usuario non ten seguidores."
+msgstr "Esta persoa non ten seguidores."
 
 #: src/components/dms/MessagesListBlockedFooter.tsx:60
 msgid "This user has blocked you"
-msgstr "Este usuario bloqueouche"
+msgstr "Esta persoa bloqueoute"
 
 #: src/components/moderation/ModerationDetailsDialog.tsx:78
 #: src/lib/moderation/useModerationCauseDescription.ts:73
 msgid "This user has blocked you. You cannot view their content."
-msgstr "Este usuario bloqueouche. Non podes ver o seu contido."
+msgstr "Esta persoa bloqueoute. Non podes ver o seu contido."
 
 #: src/lib/moderation/useGlobalLabelStrings.ts:30
 msgid "This user has requested that their content only be shown to signed-in users."
-msgstr "Este usuario solicitou que o seu contido só poida ser visto por usuarios conectados."
+msgstr ""
+"Esta persoa solicitou que o seu contido só se mostre ás persoas que "
+"iniciaron sesión."
 
 #: src/components/moderation/ModerationDetailsDialog.tsx:58
 msgid "This user is included in the <0>{0}</0> list which you have blocked."
-msgstr "Este usuario está incluído na lista <0>{0}</0> que tes bloqueada."
+msgstr "Esta persoa está incluída na listaxe <0>{0}</0> que bloqueaches."
 
 #: src/components/moderation/ModerationDetailsDialog.tsx:90
 msgid "This user is included in the <0>{0}</0> list which you have muted."
-msgstr "Este usuario está incluído na lista <0>{0}</0> que tes silenciada."
+msgstr "Esta persoa está incluída na listaxe <0>{0}</0> que silenciaches."
 
 #: src/components/NewskieDialog.tsx:65
 msgid "This user is new here. Press for more info about when they joined."
-msgstr "Este usuario é novo aquí. Premer para máis información sobre cando se uniu."
+msgstr ""
+"Esta persoa é nova aquí. Preme para obter máis información sobre cando se "
+"uniron."
 
 #: src/view/com/profile/ProfileFollows.tsx:96
 msgid "This user isn't following anyone."
-msgstr "Este usuario non sigue a ninguén."
-
-#: src/view/com/modals/SelfLabel.tsx:137
-#~ msgid "This warning is only available for posts with media attached."
-#~ msgstr "Este aviso só está dispoñíbel para publicacións con medios anexados."
+msgstr "Este persoa non segue a ninguén."
 
 #: src/components/dialogs/MutedWords.tsx:435
-msgid "This will delete \"{0}\" from your muted words. You can always add it back later."
-msgstr "Isto eliminará \"{0}\" das túas palabras silenciadas. Sempre podes engadila de novo."
-
-#: src/components/dialogs/MutedWords.tsx:283
-#~ msgid "This will delete {0} from your muted words. You can always add it back later."
-#~ msgstr "Isto eliminará {0} das túas palabras silenciadas. Sempre podes engadila de novo."
+msgid ""
+"This will delete \"{0}\" from your muted words. You can always add it back "
+"later."
+msgstr ""
+"Isto eliminará \"{0}\" das túas palabras silenciadas. Sempre podes engadilo "
+"máis tarde."
 
 #: src/view/com/util/AccountDropdownBtn.tsx:55
 msgid "This will remove @{0} from the quick access list."
-msgstr "Isto eliminará @{0} da lista de acceso rápido."
+msgstr "Isto eliminará @{0} da listaxe de acceso rápido."
 
 #: src/view/com/util/forms/PostDropdownBtn.tsx:733
-msgid "This will remove your post from this quote post for all users, and replace it with a placeholder."
-msgstr "Isto eliminará a túa publicación desta cita para todos os usuarios, e a substituirá cun marcador."
+msgid ""
+"This will remove your post from this quote post for all users, and replace "
+"it with a placeholder."
+msgstr ""
+"Esto eliminará o teu chío desta cita para todas as persoas e substituirase "
+"por un marcador de posición."
 
 #: src/view/screens/Settings/index.tsx:561
 msgid "Thread preferences"
@@ -7642,47 +6995,47 @@ msgstr "Preferencias de fíos"
 #: src/view/screens/PreferencesThreads.tsx:52
 #: src/view/screens/Settings/index.tsx:571
 msgid "Thread Preferences"
-msgstr "Preferencias de fíos"
-
-#: src/components/WhoCanReply.tsx:109
-#~ msgid "Thread settings updated"
-#~ msgstr "Axustes de fíos actualizados"
+msgstr "Preferencias de Fíos"
 
 #: src/view/screens/PreferencesThreads.tsx:114
 msgid "Threaded Mode"
-msgstr "Modo en fío"
+msgstr "Modo con fíos"
 
 #: src/Navigation.tsx:303
 msgid "Threads Preferences"
 msgstr "Preferencias de fíos"
 
 #: src/view/screens/Settings/DisableEmail2FADialog.tsx:101
-msgid "To disable the email 2FA method, please verify your access to the email address."
-msgstr "Para deshabilitar o método 2FA no correo, por favor verifica o teu acceso ao correo electrónico."
+msgid ""
+"To disable the email 2FA method, please verify your access to the email "
+"address."
+msgstr ""
+"Para desactivar o método 2FA de correo electrónico, verifica o teu acceso "
+"ao enderezo de correo electrónico."
 
 #: src/components/dms/ReportConversationPrompt.tsx:20
-msgid "To report a conversation, please report one of its messages via the conversation screen. This lets our moderators understand the context of your issue."
-msgstr "Para denunciar unha conversa, por favor denuncia unha das mensaxes a través da pantalla da conversa. Isto permite aos nosos moderadores comprender o contexto do problema."
+msgid ""
+"To report a conversation, please report one of its messages via the "
+"conversation screen. This lets our moderators understand the context of "
+"your issue."
+msgstr ""
+"Para denunciar unha conversa, informa dunha das súas mensaxes a través da "
+"pantalla de conversa. Isto permite que os nosos moderadores comprendan o "
+"contexto do teu problema."
 
 #: src/view/com/composer/videos/SelectVideoBtn.tsx:133
 msgid "To upload videos to Bluesky, you must first verify your email."
-msgstr "Para subir vídeos a Bluesky, primeiro tes que verificar o teu correo."
+msgstr ""
+"Para cargar vídeos en Bluesky, primeiro debes verificar o teu correo "
+"electrónico."
 
 #: src/components/ReportDialog/SelectLabelerView.tsx:32
 msgid "To whom would you like to send this report?"
-msgstr "A quen desexas enviar esta denuncia?"
+msgstr "A quen che gustaría enviar este informe?"
 
 #: src/components/dms/DateDivider.tsx:44
 msgid "Today"
 msgstr "Hoxe"
-
-#: src/components/dialogs/nuxs/TenMillion/index.tsx:597
-#~ msgid "Together, we're rebuilding the social internet. We're glad you're here."
-#~ msgstr "Xuntos estamos a reconstruír a internet social. Alédanos de que esteas aquí."
-
-#: src/components/dialogs/MutedWords.tsx:112
-#~ msgid "Toggle between muted word options."
-#~ msgstr "Alternar entre as opcións das palabras silenciadas."
 
 #: src/view/com/util/forms/DropdownButton.tsx:255
 msgid "Toggle dropdown"
@@ -7690,16 +7043,12 @@ msgstr "Alternar o menú despregábel"
 
 #: src/screens/Moderation/index.tsx:346
 msgid "Toggle to enable or disable adult content"
-msgstr "Alternar para habilitar ou deshabilitar o contido para adultos"
+msgstr "Activa ou desactiva o contido para persoas adultas"
 
 #: src/screens/Hashtag.tsx:87
 #: src/view/screens/Search/Search.tsx:511
 msgid "Top"
-msgstr "Superior"
-
-#: src/view/com/modals/EditImage.tsx:272
-#~ msgid "Transformations"
-#~ msgstr "Transformacións"
+msgstr "Top"
 
 #: src/components/dms/MessageMenu.tsx:103
 #: src/components/dms/MessageMenu.tsx:105
@@ -7709,11 +7058,6 @@ msgstr "Superior"
 #: src/view/com/util/forms/PostDropdownBtn.tsx:424
 msgid "Translate"
 msgstr "Traducir"
-
-#: src/view/com/util/error/ErrorScreen.tsx:82
-msgctxt "action"
-msgid "Try again"
-msgstr "Tentar de novo"
 
 #: src/screens/Onboarding/state.ts:102
 msgid "TV"
@@ -7725,19 +7069,19 @@ msgstr "Autenticación de dous factores"
 
 #: src/screens/Messages/components/MessageInput.tsx:141
 msgid "Type your message here"
-msgstr "Escribe a túa mensaxe aquí"
+msgstr "Escribe aquí a túa mensaxe"
 
 #: src/view/com/modals/ChangeHandle.tsx:415
 msgid "Type:"
-msgstr "Escribir:"
+msgstr "Tipo:"
 
 #: src/view/screens/ProfileList.tsx:594
 msgid "Un-block list"
-msgstr "Desbloquear lista"
+msgstr "Desbloquear listaxe"
 
 #: src/view/screens/ProfileList.tsx:579
 msgid "Un-mute list"
-msgstr "Desenmudecer lista"
+msgstr "Activar listaxe"
 
 #: src/screens/Login/ForgotPasswordForm.tsx:68
 #: src/screens/Login/index.tsx:76
@@ -7746,11 +7090,11 @@ msgstr "Desenmudecer lista"
 #: src/screens/Signup/index.tsx:71
 #: src/view/com/modals/ChangePassword.tsx:71
 msgid "Unable to contact your service. Please check your Internet connection."
-msgstr "Non é posíbel conectar co teu servizo. Por favor, verifica a túa conexión a internet."
+msgstr "Non se puido contactar co teu servizo. Comproba a túa conexión a Internet."
 
 #: src/screens/StarterPack/StarterPackScreen.tsx:648
 msgid "Unable to delete"
-msgstr "Non é posíbel eliminar"
+msgstr "Non se pode eliminar"
 
 #: src/components/dms/MessagesListBlockedFooter.tsx:89
 #: src/components/dms/MessagesListBlockedFooter.tsx:96
@@ -7760,11 +7104,6 @@ msgstr "Non é posíbel eliminar"
 #: src/screens/Profile/Header/ProfileHeaderStandard.tsx:273
 #: src/view/com/profile/ProfileMenu.tsx:341
 #: src/view/screens/ProfileList.tsx:685
-msgid "Unblock"
-msgstr "Desbloquear"
-
-#: src/screens/Profile/Header/ProfileHeaderStandard.tsx:192
-msgctxt "action"
 msgid "Unblock"
 msgstr "Desbloquear"
 
@@ -7781,84 +7120,57 @@ msgstr "Desbloquear Conta"
 #: src/screens/Profile/Header/ProfileHeaderStandard.tsx:267
 #: src/view/com/profile/ProfileMenu.tsx:323
 msgid "Unblock Account?"
-msgstr "Desbloquear a conta?"
+msgstr "Desbloquear Conta?"
 
 #: src/view/com/util/post-ctrls/RepostButton.tsx:71
 #: src/view/com/util/post-ctrls/RepostButton.web.tsx:72
 #: src/view/com/util/post-ctrls/RepostButton.web.tsx:76
 msgid "Undo repost"
-msgstr ""
-
-#: src/view/com/profile/FollowButton.tsx:61
-msgctxt "action"
-msgid "Unfollow"
-msgstr "Deixar de seguir"
-
-#: src/view/com/profile/ProfileHeaderSuggestedFollows.tsx:247
-#~ msgid "Unfollow"
-#~ msgstr "Deixar de seguir"
+msgstr "Desfacer o rechouchío"
 
 #: src/screens/Profile/Header/ProfileHeaderStandard.tsx:207
 msgid "Unfollow {0}"
-msgstr "Deixar de seguir a {0}"
+msgstr "Deixa de seguir {0}"
 
 #: src/view/com/profile/ProfileMenu.tsx:221
 #: src/view/com/profile/ProfileMenu.tsx:231
 msgid "Unfollow Account"
-msgstr "Deixar de seguir a conta"
-
-#: src/view/com/util/post-ctrls/PostCtrls.tsx:197
-#~ msgid "Unlike"
-#~ msgstr "Non me gusta"
+msgstr "Deixar de seguir a esta conta"
 
 #: src/view/screens/ProfileFeed.tsx:576
 msgid "Unlike this feed"
-msgstr "Non me gusta esta fonte"
+msgstr "Non me gusta esta canle"
 
 #: src/components/TagMenu/index.tsx:248
 #: src/view/screens/ProfileList.tsx:692
 msgid "Unmute"
-msgstr "Desenmudecer"
-
-#: src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerNative.tsx:156
-#: src/view/com/util/post-embeds/VideoEmbedInner/web-controls/VolumeControl.tsx:93
-msgctxt "video"
-msgid "Unmute"
-msgstr "Desenmudecer"
+msgstr "Activar"
 
 #: src/components/TagMenu/index.web.tsx:115
 msgid "Unmute {truncatedTag}"
-msgstr "Desenmudecer {truncatedTag}"
+msgstr "Activar {truncatedTag}"
 
 #: src/view/com/profile/ProfileMenu.tsx:258
 #: src/view/com/profile/ProfileMenu.tsx:264
 msgid "Unmute Account"
-msgstr "Desenmudecer conta"
+msgstr "Activar conta"
 
 #: src/components/TagMenu/index.tsx:204
 msgid "Unmute all {displayTag} posts"
-msgstr "Desenmudecer todas as publicacións con {displayTag}"
+msgstr "Activar todos os chíos de {displayTag}"
 
 #: src/components/dms/ConvoMenu.tsx:176
 msgid "Unmute conversation"
-msgstr "Desenmudecer conversa"
-
-#: src/components/dms/ConvoMenu.tsx:140
-#~ msgid "Unmute notifications"
-#~ msgstr "Desenmudecer notificacións"
+msgstr "Activar a conversa"
 
 #: src/view/com/util/forms/PostDropdownBtn.tsx:507
 #: src/view/com/util/forms/PostDropdownBtn.tsx:512
 msgid "Unmute thread"
-msgstr "Desenmudecer fío"
+msgstr "Activar o fío"
 
 #: src/view/com/util/post-embeds/VideoEmbedInner/web-controls/VideoControls.tsx:321
 msgid "Unmute video"
-msgstr "Desenmudecer vídeo"
-
-#: src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerNative.tsx:168
-#~ msgid "Unmuted"
-#~ msgstr "desenmudecido"
+msgstr "Activar o audio do vídeo"
 
 #: src/view/screens/ProfileFeed.tsx:296
 #: src/view/screens/ProfileList.tsx:676
@@ -7876,36 +7188,32 @@ msgstr "Desfixar do perfil"
 
 #: src/view/screens/ProfileList.tsx:559
 msgid "Unpin moderation list"
-msgstr "Desfixar lista de moderación"
+msgstr "Desfixar a listaxe de moderación"
 
 #: src/view/screens/ProfileList.tsx:356
 msgid "Unpinned from your feeds"
-msgstr "Desfixado das túas fontes"
+msgstr "Desfixouse das túas canles"
 
 #: src/screens/Profile/Header/ProfileHeaderLabeler.tsx:226
 msgid "Unsubscribe"
-msgstr "Eliminar subscrición"
+msgstr "Cancelar a subscrición"
 
 #: src/screens/List/ListHiddenScreen.tsx:184
 #: src/screens/List/ListHiddenScreen.tsx:194
 msgid "Unsubscribe from list"
-msgstr "Eliminar subscrición á lista"
+msgstr "Cancelar a subscrición da listaxe"
 
 #: src/screens/Profile/Header/ProfileHeaderLabeler.tsx:193
 msgid "Unsubscribe from this labeler"
-msgstr ""
+msgstr "Cancelar a subscrición a esta etiquetadora"
 
 #: src/screens/List/ListHiddenScreen.tsx:86
 msgid "Unsubscribed from list"
-msgstr "Eliminada a subscrición á lista"
+msgstr "Cancelouse a subscrición da listaxe"
 
 #: src/view/com/composer/videos/SelectVideoBtn.tsx:72
 msgid "Unsupported video type: {mimeType}"
-msgstr "Formato de vídeo non soportado: {mimeType}"
-
-#: src/lib/moderation/useReportOptions.ts:85
-#~ msgid "Unwanted sexual content"
-#~ msgstr "Contenido sexual no deseado"
+msgstr "Tipo de vídeo non compatíbel: {mimeType}"
 
 #: src/lib/moderation/useReportOptions.ts:77
 #: src/lib/moderation/useReportOptions.ts:90
@@ -7913,24 +7221,20 @@ msgid "Unwanted Sexual Content"
 msgstr "Contido sexual non desexado"
 
 #: src/view/com/modals/UserAddRemoveLists.tsx:82
-#~ msgid "Update {displayName} in Lists"
-#~ msgstr "Actualizar {displayName} nas listas"
-
-#: src/view/com/modals/UserAddRemoveLists.tsx:82
 msgid "Update <0>{displayName}</0> in Lists"
-msgstr "Actualizar <0>{displayName}</0> nas Listas"
+msgstr "Actualizar <0>{displayName}</0> nas listaxes"
 
 #: src/view/com/modals/ChangeHandle.tsx:495
 msgid "Update to {handle}"
-msgstr "Actualizar en {handle}"
+msgstr "Actualizar a {handle}"
 
 #: src/view/com/util/forms/PostDropdownBtn.tsx:311
 msgid "Updating quote attachment failed"
-msgstr "Produciuse un erro ao actualizar o anexo da cita"
+msgstr "Produciuse un erro ao actualizar o anexo da cotización"
 
 #: src/view/com/util/forms/PostDropdownBtn.tsx:341
 msgid "Updating reply visibility failed"
-msgstr "Produciuse un erro ao actualizar a visibilidade da resposta"
+msgstr "Produciuse un erro ao actualizar a visibilidade das respostas"
 
 #: src/screens/Login/SetNewPasswordForm.tsx:180
 msgid "Updating..."
@@ -7938,81 +7242,85 @@ msgstr "Actualizando..."
 
 #: src/screens/Onboarding/StepProfile/index.tsx:290
 msgid "Upload a photo instead"
-msgstr "Subir unha foto no seu lugar"
+msgstr "Carga unha foto no seu lugar"
 
 #: src/view/com/modals/ChangeHandle.tsx:441
 msgid "Upload a text file to:"
-msgstr "Subir un ficheiro de texto a:"
+msgstr "Carga un ficheiro de texto a:"
 
 #: src/view/com/util/UserAvatar.tsx:371
 #: src/view/com/util/UserAvatar.tsx:374
 #: src/view/com/util/UserBanner.tsx:123
 #: src/view/com/util/UserBanner.tsx:126
 msgid "Upload from Camera"
-msgstr "Subir dende a cámara"
+msgstr "Cargar desde a cámara"
 
 #: src/view/com/util/UserAvatar.tsx:388
 #: src/view/com/util/UserBanner.tsx:140
 msgid "Upload from Files"
-msgstr "Subir dende os ficheiros"
+msgstr "Cargar desde ficheiros"
 
 #: src/view/com/util/UserAvatar.tsx:382
 #: src/view/com/util/UserAvatar.tsx:386
 #: src/view/com/util/UserBanner.tsx:134
 #: src/view/com/util/UserBanner.tsx:138
 msgid "Upload from Library"
-msgstr "Subir dende a biblioteca"
+msgstr "Cargar desde a biblioteca"
 
 #: src/lib/api/index.ts:272
 msgid "Uploading images..."
-msgstr "Subindo imaxes..."
+msgstr "Cargando imaxes..."
 
 #: src/lib/api/index.ts:326
 #: src/lib/api/index.ts:350
 msgid "Uploading link thumbnail..."
-msgstr ""
+msgstr "Cargando miniatura da ligazón..."
 
 #: src/view/com/composer/Composer.tsx:1344
 msgid "Uploading video..."
-msgstr "Subindo vídeo..."
+msgstr "Cargando vídeo..."
 
 #: src/view/com/modals/ChangeHandle.tsx:395
 msgid "Use a file on your server"
 msgstr "Usar un ficheiro no teu servidor"
 
 #: src/view/screens/AppPasswords.tsx:205
-msgid "Use app passwords to login to other Bluesky clients without giving full access to your account or password."
-msgstr "Usa os contrasinais de aplicación para iniciar sesión noutros clientes de Bluesky sen dar acceso total á túa conta ou contrasinal."
+msgid ""
+"Use app passwords to login to other Bluesky clients without giving full "
+"access to your account or password."
+msgstr ""
+"Usar as contrasinais das aplicacións para iniciar sesión noutros clientes "
+"de Bluesky sen dar acceso total á túa conta ou contrasinal."
 
 #: src/view/com/modals/ChangeHandle.tsx:506
 msgid "Use bsky.social as hosting provider"
-msgstr "Usar bsky.social como provedor de hospedaxe"
+msgstr "Usar bsky.social como provedor"
 
 #: src/view/com/modals/ChangeHandle.tsx:505
 msgid "Use default provider"
-msgstr "Usar o provedor predefinido"
+msgstr "Usar o provedor predeterminado"
 
 #: src/view/com/modals/InAppBrowserConsent.tsx:53
 #: src/view/com/modals/InAppBrowserConsent.tsx:55
 msgid "Use in-app browser"
-msgstr ""
+msgstr "Usar o navegador na aplicación"
 
 #: src/view/com/modals/InAppBrowserConsent.tsx:63
 #: src/view/com/modals/InAppBrowserConsent.tsx:65
 msgid "Use my default browser"
-msgstr "Usar o meu navegador predefinido"
+msgstr "Usar o meu navegador predeterminado"
 
 #: src/screens/Feeds/NoSavedFeedsOfAnyType.tsx:53
 msgid "Use recommended"
-msgstr "Uso recomendado"
+msgstr "Usar recomendados"
 
 #: src/view/com/modals/ChangeHandle.tsx:387
 msgid "Use the DNS panel"
-msgstr ""
+msgstr "Usar o panel DNS"
 
 #: src/view/com/modals/AddAppPasswords.tsx:206
 msgid "Use this to sign into the other app along with your handle."
-msgstr "Emprega isto para entrar na outra aplicación xunto co teu nome de usuario."
+msgstr "Úsao para iniciar sesión noutra aplicación xunto co teu identificador."
 
 #: src/view/com/modals/InviteCodes.tsx:201
 msgid "Used by:"
@@ -8021,81 +7329,77 @@ msgstr "Usado por:"
 #: src/components/moderation/ModerationDetailsDialog.tsx:70
 #: src/lib/moderation/useModerationCauseDescription.ts:61
 msgid "User Blocked"
-msgstr "Usuario bloqueado"
+msgstr "Persoas bloqueada"
 
 #: src/lib/moderation/useModerationCauseDescription.ts:53
 msgid "User Blocked by \"{0}\""
-msgstr "Usuario bloqueado por \"{0}\""
+msgstr "Persoas bloqueada por \"{0}\""
 
 #: src/components/dms/BlockedByListDialog.tsx:27
 msgid "User blocked by list"
-msgstr ""
+msgstr "Persoas bloqueada por listaxe"
 
 #: src/components/moderation/ModerationDetailsDialog.tsx:56
 msgid "User Blocked by List"
-msgstr ""
+msgstr "Persoas Bloqueada pola Listaxe"
 
 #: src/lib/moderation/useModerationCauseDescription.ts:71
 msgid "User Blocking You"
-msgstr ""
+msgstr "A persoas estate bloqueando"
 
 #: src/components/moderation/ModerationDetailsDialog.tsx:76
 msgid "User Blocks You"
-msgstr ""
+msgstr "A persoas bloquéate"
 
 #: src/view/com/modals/UserAddRemoveLists.tsx:214
 msgid "User list by {0}"
-msgstr ""
+msgstr "Listaxe de persoas por {0}"
 
 #: src/view/screens/ProfileList.tsx:890
 msgid "User list by <0/>"
-msgstr ""
+msgstr "Listaxe de persoas por <0/>"
 
 #: src/view/com/modals/UserAddRemoveLists.tsx:212
 #: src/view/screens/ProfileList.tsx:888
 msgid "User list by you"
-msgstr ""
+msgstr "Listaxe de persoas por ti"
 
 #: src/view/com/modals/CreateOrEditList.tsx:176
 msgid "User list created"
-msgstr ""
+msgstr "Listaxe de persoas creada"
 
 #: src/view/com/modals/CreateOrEditList.tsx:162
 msgid "User list updated"
-msgstr ""
+msgstr "Listaxe de persoas actualizada"
 
 #: src/view/screens/Lists.tsx:66
 msgid "User Lists"
-msgstr ""
+msgstr "Listaxes de persoas"
 
 #: src/screens/Login/LoginForm.tsx:183
 msgid "Username or email address"
-msgstr "Nome de usuario ou enderezo de correo"
+msgstr "Alcume ou enderezo de correo electrónico"
 
 #: src/view/screens/ProfileList.tsx:924
 msgid "Users"
-msgstr "Usuarios"
-
-#: src/components/WhoCanReply.tsx:280
-#~ msgid "users followed by <0/>"
-#~ msgstr "usuarios seguidos por <0/>"
+msgstr "Persoas"
 
 #: src/components/WhoCanReply.tsx:258
 msgid "users followed by <0>@{0}</0>"
-msgstr "usuarios seguidos por <0>@{0}</0>"
+msgstr "persoas seguidas por <0>@{0}</0>"
 
 #: src/screens/Messages/Settings.tsx:86
 #: src/screens/Messages/Settings.tsx:89
 msgid "Users I follow"
-msgstr "Usuarios que eu sigo"
+msgstr "Persoas que sigo"
 
 #: src/components/dialogs/PostInteractionSettingsDialog.tsx:417
 msgid "Users in \"{0}\""
-msgstr "Usuarios en \"{0}\""
+msgstr "Persoas en \"{0}\""
 
 #: src/components/LikesDialog.tsx:83
 msgid "Users that have liked this content or profile"
-msgstr ""
+msgstr "Persoas ás que lles gustou este contido ou perfil"
 
 #: src/view/com/modals/ChangeHandle.tsx:423
 msgid "Value:"
@@ -8103,37 +7407,33 @@ msgstr "Valor:"
 
 #: src/view/com/composer/videos/SelectVideoBtn.tsx:131
 msgid "Verified email required"
-msgstr "Requírese un correo verificado"
-
-#: src/view/com/modals/ChangeHandle.tsx:510
-#~ msgid "Verify {0}"
-#~ msgstr "Verificar {0}"
+msgstr "É necesario un correo electrónico verificado"
 
 #: src/view/com/modals/ChangeHandle.tsx:497
 msgid "Verify DNS Record"
-msgstr "Verificar o rexistro DNS"
+msgstr "Verificar rexistro DNS"
 
 #: src/view/screens/Settings/index.tsx:937
 msgid "Verify email"
-msgstr "Verificar correo"
+msgstr "Verificar correo electrónico"
 
 #: src/components/dialogs/VerifyEmailDialog.tsx:120
 #: src/components/intents/VerifyEmailIntentDialog.tsx:67
 msgid "Verify email dialog"
-msgstr "Diálogo de verificación de correo"
+msgstr "Verificación de correo electrónico"
 
 #: src/view/screens/Settings/index.tsx:962
 msgid "Verify my email"
-msgstr "Verificar o meu correo"
+msgstr "Verifica o meu correo electrónico"
 
 #: src/view/screens/Settings/index.tsx:971
 msgid "Verify My Email"
-msgstr "Verificar o meu correo"
+msgstr "Verifica o meu correo electrónico"
 
 #: src/view/com/modals/ChangeEmail.tsx:200
 #: src/view/com/modals/ChangeEmail.tsx:202
 msgid "Verify New Email"
-msgstr "Verificar correo novo"
+msgstr "Verificar o novo correo electrónico"
 
 #: src/view/com/composer/videos/SelectVideoBtn.tsx:135
 msgid "Verify now"
@@ -8141,12 +7441,12 @@ msgstr "Verificar agora"
 
 #: src/view/com/modals/ChangeHandle.tsx:498
 msgid "Verify Text File"
-msgstr "Verificar ficheiro de texto"
+msgstr "Verificar o ficheiro de texto"
 
 #: src/components/dialogs/VerifyEmailDialog.tsx:71
 #: src/view/com/modals/VerifyEmail.tsx:111
 msgid "Verify Your Email"
-msgstr "Verifica o teu correo"
+msgstr "Verifica o teu correo electrónico"
 
 #: src/view/screens/Settings/index.tsx:890
 msgid "Version {appVersion} {bundleInfo}"
@@ -8159,7 +7459,7 @@ msgstr "Vídeo"
 
 #: src/view/com/composer/state/video.ts:372
 msgid "Video failed to process"
-msgstr "Non foi posíbel procesar o vídeo"
+msgstr "Non se puido procesar o vídeo"
 
 #: src/screens/Onboarding/index.tsx:39
 #: src/screens/Onboarding/state.ts:90
@@ -8168,23 +7468,19 @@ msgstr "Videoxogos"
 
 #: src/view/com/util/post-embeds/VideoEmbed.web.tsx:167
 msgid "Video not found."
-msgstr "Vídeo non atopado."
+msgstr "Non se encontrou o vídeo."
 
 #: src/view/com/composer/videos/SubtitleDialog.tsx:99
 msgid "Video settings"
-msgstr "Axustes de vídeo"
+msgstr "Axustes do video"
 
 #: src/view/com/composer/Composer.tsx:1354
 msgid "Video uploaded"
-msgstr "Vídeo subido"
+msgstr "Vídeo cargado"
 
 #: src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerNative.tsx:84
 msgid "Video: {0}"
 msgstr "Vídeo: {0}"
-
-#: src/view/com/composer/videos/state.ts:27
-#~ msgid "Videos cannot be larger than 50MB"
-#~ msgstr "Os vídeos non poden superar os 50MB"
 
 #: src/view/com/composer/videos/SelectVideoBtn.tsx:79
 #: src/view/com/composer/videos/VideoPreview.web.tsx:44
@@ -8206,23 +7502,23 @@ msgstr "Ver o perfil de {displayName}"
 
 #: src/components/TagMenu/index.tsx:149
 msgid "View all posts by @{authorHandle} with tag {displayTag}"
-msgstr "Ver todas as publicacións de @{authorHandle} coa etiqueta {displayTag}"
+msgstr "Ver todos os chíos de @{authorHandle} coa etiqueta {displayTag}"
 
 #: src/components/TagMenu/index.tsx:103
 msgid "View all posts with tag {displayTag}"
-msgstr "Ver todas as publicacións coa etiqueta {displayTag}"
+msgstr "Ver todos os chíos coa etiqueta {displayTag}"
 
 #: src/components/ProfileHoverCard/index.web.tsx:433
 msgid "View blocked user's profile"
-msgstr "Ver o perfil do usuario bloqueado"
+msgstr "Ver o perfil da persoa bloqueada"
 
 #: src/view/screens/Settings/ExportCarDialog.tsx:96
 msgid "View blogpost for more details"
-msgstr "Ver publicación no blog para máis detalles"
+msgstr "Consulta a publicación do blog para obter máis detalles"
 
 #: src/view/screens/Log.tsx:57
 msgid "View debug entry"
-msgstr "Ver entrada de depuración"
+msgstr "Ver a entrada de depuración"
 
 #: src/components/ReportDialog/SelectReportOptionView.tsx:139
 msgid "View details"
@@ -8230,15 +7526,15 @@ msgstr "Ver detalles"
 
 #: src/components/ReportDialog/SelectReportOptionView.tsx:134
 msgid "View details for reporting a copyright violation"
-msgstr "Ver os detalles para informar dunha violación do copyright"
+msgstr "Consulta os detalles para informar dunha infracción do copyright"
 
 #: src/view/com/posts/FeedSlice.tsx:136
 msgid "View full thread"
-msgstr "Ver o fío completo"
+msgstr "Ver fío completo"
 
 #: src/components/moderation/LabelsOnMe.tsx:47
 msgid "View information about these labels"
-msgstr "Ver a información sobre estas etiquetas"
+msgstr "Consulta información sobre estas etiquetas"
 
 #: src/components/ProfileHoverCard/index.web.tsx:419
 #: src/components/ProfileHoverCard/index.web.tsx:439
@@ -8248,7 +7544,7 @@ msgstr "Ver a información sobre estas etiquetas"
 #: src/view/com/util/PostMeta.tsx:77
 #: src/view/com/util/PostMeta.tsx:92
 msgid "View profile"
-msgstr "Ver o perfil"
+msgstr "Ver perfil"
 
 #: src/view/com/profile/ProfileSubpageHeader.tsx:127
 msgid "View the avatar"
@@ -8256,95 +7552,95 @@ msgstr "Ver o avatar"
 
 #: src/components/LabelingServiceCard/index.tsx:162
 msgid "View the labeling service provided by @{0}"
-msgstr "Ver o servizo de etiquetado fornecido por @{0}"
+msgstr "Consulta o servizo de etiquetado proporcionado por @{0}"
 
 #: src/view/screens/ProfileFeed.tsx:588
 msgid "View users who like this feed"
-msgstr "Ver os usuarios aos que lles gusta esta fonte"
+msgstr "Consulta as persoas ás que lles gusta esta canle"
 
 #: src/screens/Moderation/index.tsx:275
 msgid "View your blocked accounts"
-msgstr "Ver as túas contas bloqueadas"
+msgstr "Consulta as túas contas bloqueadas"
 
 #: src/view/com/home/HomeHeaderLayout.web.tsx:78
 #: src/view/com/home/HomeHeaderLayoutMobile.tsx:89
 msgid "View your feeds and explore more"
-msgstr "Ver as túas fontes e explorar máis"
+msgstr "Consulta as túas canles e explora máis"
 
 #: src/screens/Moderation/index.tsx:245
 msgid "View your moderation lists"
-msgstr "Ver a túa lista de moderación"
+msgstr "Consulta as túas listaxes de moderación"
 
 #: src/screens/Moderation/index.tsx:260
 msgid "View your muted accounts"
-msgstr "Ver as túas contas silenciadas"
+msgstr "Consulta as túas contas silenciadas"
 
 #: src/view/com/modals/LinkWarning.tsx:89
 #: src/view/com/modals/LinkWarning.tsx:95
 msgid "Visit Site"
-msgstr "Visitar sitio"
+msgstr "Visitar o sitio"
 
 #: src/components/moderation/LabelPreference.tsx:135
 #: src/lib/moderation/useLabelBehaviorDescription.ts:17
 #: src/lib/moderation/useLabelBehaviorDescription.ts:22
 msgid "Warn"
-msgstr "Aviso"
+msgstr "Advertir"
 
 #: src/lib/moderation/useLabelBehaviorDescription.ts:48
 msgid "Warn content"
-msgstr "Aviso de contido"
+msgstr "Advertir contido"
 
 #: src/lib/moderation/useLabelBehaviorDescription.ts:46
 msgid "Warn content and filter from feeds"
-msgstr "Aviso de contido e filtrar polas fontes"
+msgstr "Advirtir contido e filtra desde canles"
 
 #: src/screens/Hashtag.tsx:218
 msgid "We couldn't find any results for that hashtag."
-msgstr "Non foi posíbel atopar resultados para este cancelo."
+msgstr "Non puidemos atopar ningún resultado para ese cancelo."
 
 #: src/screens/Messages/Conversation.tsx:110
 msgid "We couldn't load this conversation"
-msgstr "Non foi posíbel cargar esta conversa"
+msgstr "Non puidemos cargar esta conversa"
 
 #: src/screens/SignupQueued.tsx:139
 msgid "We estimate {estimatedTime} until your account is ready."
-msgstr "Estimamos {estimatedTime} até que a túa conta estea lista."
+msgstr "Estimamos o {estimatedTime} ata que a túa conta estea lista."
 
 #: src/components/intents/VerifyEmailIntentDialog.tsx:107
 msgid "We have sent another verification email to <0>{0}</0>."
-msgstr "Enviamos outro correo de verificación a <0>{0}</0>."
+msgstr "Enviamos outro correo electrónico de verificación a <0>{0}</0>."
 
 #: src/screens/Onboarding/StepFinished.tsx:229
 msgid "We hope you have a wonderful time. Remember, Bluesky is:"
-msgstr "Agardamos que o pases ben. Lembra, Bluesky é:"
+msgstr "Esperamos que o pases de marabilla. Lembra que Bluesky é:"
 
 #: src/view/com/posts/DiscoverFallbackHeader.tsx:29
 msgid "We ran out of posts from your follows. Here's the latest from <0/>."
-msgstr "Remataron as publicacións dos teus seguidos. Aquí tes o último de <0/>."
-
-#: src/components/dialogs/MutedWords.tsx:203
-#~ msgid "We recommend avoiding common words that appear in many posts, since it can result in no posts being shown."
-#~ msgstr "Recomendamos evitar palabras comúns que aparencen en moitas publicacións, o que podería facer que non se amosen publicacións."
-
-#: src/screens/Onboarding/StepAlgoFeeds/index.tsx:125
-#~ msgid "We recommend our \"Discover\" feed:"
-#~ msgstr "Recomendamos a nosa fonte \"Descubrir\":"
+msgstr "Quedamos sen chíos das persoas que segues. Aquí tes o último de <0/>."
 
 #: src/view/com/composer/state/video.ts:431
-msgid "We were unable to determine if you are allowed to upload videos. Please try again."
-msgstr "Non puidemos determinar se tes permiso para subir vídeos. Téntao de novo."
+msgid ""
+"We were unable to determine if you are allowed to upload videos. Please try "
+"again."
+msgstr "Non puidemos determinar se tes permiso para cargar vídeos. Téntao de novo."
 
 #: src/components/dialogs/BirthDateSettings.tsx:51
 msgid "We were unable to load your birth date preferences. Please try again."
-msgstr "Non puidemos cargar as túas preferencias da data de nacemento. Téntao de novo."
+msgstr ""
+"Non puidemos cargar as túas preferencias de data de nacemento. Téntao de "
+"novo."
 
 #: src/screens/Moderation/index.tsx:420
 msgid "We were unable to load your configured labelers at this time."
-msgstr "Non puidemos cargar os teus etiquetados configurados neste intre."
+msgstr "Non puidemos cargar os teus etiquetadores configurados neste momento."
 
 #: src/screens/Onboarding/StepInterests/index.tsx:129
-msgid "We weren't able to connect. Please try again to continue setting up your account. If it continues to fail, you can skip this flow."
-msgstr "Non puidemos conectar. Por favor, téntao de novo para continuar configurando a túa conta. Se o problema persiste, podes omitir este proceso."
+msgid ""
+"We weren't able to connect. Please try again to continue setting up your "
+"account. If it continues to fail, you can skip this flow."
+msgstr ""
+"Non puidemos conectarnos. Téntao de novo para continuar configurando a túa "
+"conta. Se continúa fallando, podes omitir este fluxo."
 
 #: src/screens/SignupQueued.tsx:143
 msgid "We will let you know when your account is ready."
@@ -8352,7 +7648,7 @@ msgstr "Informarémosche cando a túa conta estea lista."
 
 #: src/screens/Onboarding/StepInterests/index.tsx:134
 msgid "We'll use this to help customize your experience."
-msgstr "Empregaremos isto para axudar na personalización da túa experencia."
+msgstr "Usarémolo para personalizar a túa experiencia."
 
 #: src/components/dms/dialogs/SearchablePeopleList.tsx:87
 msgid "We're having network issues, try again"
@@ -8360,52 +7656,64 @@ msgstr "Temos problemas de rede, téntao de novo"
 
 #: src/components/dialogs/nuxs/NeueTypography.tsx:54
 msgid "We're introducing a new theme font, along with adjustable font sizing."
-msgstr ""
+msgstr "Introducimos unha nova fonte temática, xunto cun tamaño de fonte axustábel."
 
 #: src/screens/Signup/index.tsx:94
 msgid "We're so excited to have you join us!"
-msgstr "Estamos moi felices de que te unas a nós!"
+msgstr "Que emoción que esteas aquí!"
 
 #: src/view/screens/ProfileList.tsx:113
-msgid "We're sorry, but we were unable to resolve this list. If this persists, please contact the list creator, @{handleOrDid}."
-msgstr "Tivemos un problema para resolver esta lista. Se persiste, contacta co creador da lista, @{handleOrDid}."
+msgid ""
+"We're sorry, but we were unable to resolve this list. If this persists, "
+"please contact the list creator, @{handleOrDid}."
+msgstr ""
+"Sentímolo, mais non puidemos resolver esta lista. Se isto persiste, póñase "
+"en contacto com quen creou a listaxe, @{handleOrDid}."
 
 #: src/components/dialogs/MutedWords.tsx:378
-msgid "We're sorry, but we weren't able to load your muted words at this time. Please try again."
+msgid ""
+"We're sorry, but we weren't able to load your muted words at this time. "
+"Please try again."
 msgstr ""
+"Sentímolo, mais non puidemos cargar as túas palabras silenciadas neste "
+"momento. Téntao de novo."
 
 #: src/view/screens/Search/Search.tsx:212
-msgid "We're sorry, but your search could not be completed. Please try again in a few minutes."
+msgid ""
+"We're sorry, but your search could not be completed. Please try again in a "
+"few minutes."
 msgstr ""
+"Sentímolo, mais a túa busca non se puido completar. Téntao de novo nuns "
+"minutos."
 
 #: src/view/com/composer/Composer.tsx:361
 msgid "We're sorry! The post you are replying to has been deleted."
-msgstr "Sentímolo, a publicación á que estas a responder foi eliminada."
+msgstr "Sentímolo! Eliminouse o chío ao que estás respondendo."
 
 #: src/components/Lists.tsx:220
 #: src/view/screens/NotFound.tsx:50
 msgid "We're sorry! We can't find the page you were looking for."
-msgstr "Sentímolo, non foi posíbel atopar a páxina que procuras."
-
-#: src/screens/Profile/Header/ProfileHeaderLabeler.tsx:330
-#~ msgid "We're sorry! You can only subscribe to ten labelers, and you've reached your limit of ten."
-#~ msgstr "Sentímolo, só podes subscribirte a dez etiquetadores, e xa acadaches o límite."
+msgstr "Sentímolo! Non podemos encontrar a páxina que buscabas."
 
 #: src/screens/Profile/Header/ProfileHeaderLabeler.tsx:331
-msgid "We're sorry! You can only subscribe to twenty labelers, and you've reached your limit of twenty."
-msgstr "Sentímolo, só podes subscribirte a vinte etiquetadores, e xa acadaches o límite."
+msgid ""
+"We're sorry! You can only subscribe to twenty labelers, and you've reached "
+"your limit of twenty."
+msgstr ""
+"Sentímolo! Só podes subscribirte a vinte etiquetadoras e alcanzaches o "
+"límite de vinte."
 
 #: src/screens/Deactivated.tsx:128
 msgid "Welcome back!"
-msgstr "Benvido/a de novo!"
+msgstr "Xa estás de volta!"
 
 #: src/components/NewskieDialog.tsx:103
 msgid "Welcome, friend!"
-msgstr "Benvido/a, amigo/a!"
+msgstr "Dámosche a benvida!"
 
 #: src/screens/Onboarding/StepInterests/index.tsx:126
 msgid "What are your interests?"
-msgstr "Que é o que che interesa?"
+msgstr "Cales son os teus intereses?"
 
 #: src/screens/StarterPack/Wizard/StepDetails.tsx:42
 msgid "What do you want to call your starter pack?"
@@ -8415,73 +7723,56 @@ msgstr "Como queres chamar ao teu paquete de inicio?"
 #: src/view/com/auth/SplashScreen.web.tsx:98
 #: src/view/com/composer/Composer.tsx:573
 msgid "What's up?"
-msgstr "Que foi?"
+msgstr "Que hai de novo?"
 
 #: src/view/com/modals/lang-settings/PostLanguagesSettings.tsx:79
 msgid "Which languages are used in this post?"
-msgstr "Que linguas son usadas nesta publicación?"
+msgstr "En que idioma está este chío?"
 
 #: src/view/com/modals/lang-settings/ContentLanguagesSettings.tsx:78
 msgid "Which languages would you like to see in your algorithmic feeds?"
-msgstr "Que linguas gustaríache ver nas túas fontes?"
+msgstr "Que idiomas che gustaría ver nas túas canles algorítmicas?"
 
 #: src/components/WhoCanReply.tsx:179
 msgid "Who can interact with this post?"
-msgstr "Quen pode interactuar con esta publicación?"
-
-#: src/components/dms/MessagesNUX.tsx:110
-#: src/components/dms/MessagesNUX.tsx:124
-#~ msgid "Who can message you?"
-#~ msgstr "Quen pode enviarte mensaxes?"
+msgstr "Quen pode interactuar con este chío?"
 
 #: src/components/WhoCanReply.tsx:87
 msgid "Who can reply"
 msgstr "Quen pode responder"
 
-#: src/components/WhoCanReply.tsx:212
-#~ msgid "Who can reply dialog"
-#~ msgstr "Quién puede responder en el diálogo"
-
-#: src/components/WhoCanReply.tsx:216
-#~ msgid "Who can reply?"
-#~ msgstr "Quen pode responder?"
-
 #: src/screens/Home/NoFeedsPinned.tsx:79
 #: src/screens/Messages/ChatList.tsx:183
 msgid "Whoops!"
-msgstr "Vaites!"
+msgstr "Vaia!"
 
 #: src/components/ReportDialog/SelectReportOptionView.tsx:44
 msgid "Why should this content be reviewed?"
-msgstr "Por que este contido debe ser revisado?"
+msgstr "Por que se debería revisar este contido?"
 
 #: src/components/ReportDialog/SelectReportOptionView.tsx:57
 msgid "Why should this feed be reviewed?"
-msgstr "Por que esta fonte debe ser revisada?"
+msgstr "Por que se debería revisar esta canle?"
 
 #: src/components/ReportDialog/SelectReportOptionView.tsx:54
 msgid "Why should this list be reviewed?"
-msgstr "Por que esta lista debe ser revisada?"
+msgstr "Por que se debería revisar esta listaxe?"
 
 #: src/components/ReportDialog/SelectReportOptionView.tsx:63
 msgid "Why should this message be reviewed?"
-msgstr "Por que esta mensaxe debe ser revisada?"
+msgstr "Por que se debería revisar esta mensaxe?"
 
 #: src/components/ReportDialog/SelectReportOptionView.tsx:51
 msgid "Why should this post be reviewed?"
-msgstr "Por que esta publicación debe ser revisada?"
+msgstr "Por que se debería revisar este chío?"
 
 #: src/components/ReportDialog/SelectReportOptionView.tsx:60
 msgid "Why should this starter pack be reviewed?"
-msgstr "Por que este paquete de inicio debe ser revisado?"
+msgstr "Por que se debería revisar este paquete inicial?"
 
 #: src/components/ReportDialog/SelectReportOptionView.tsx:48
 msgid "Why should this user be reviewed?"
-msgstr "Por que este usuario debe ser revisado?"
-
-#: src/view/com/modals/crop-image/CropImage.web.tsx:125
-#~ msgid "Wide"
-#~ msgstr "Largo"
+msgstr "Por que se debería revisar esta persoa?"
 
 #: src/screens/Messages/components/MessageInput.tsx:142
 #: src/screens/Messages/components/MessageInput.web.tsx:198
@@ -8490,7 +7781,7 @@ msgstr "Escribe unha mensaxe"
 
 #: src/view/com/composer/Composer.tsx:630
 msgid "Write post"
-msgstr "Escribir publicación"
+msgstr "Escribe un chío"
 
 #: src/view/com/composer/Composer.tsx:572
 #: src/view/com/post-thread/PostThreadComposePrompt.tsx:71
@@ -8500,7 +7791,7 @@ msgstr "Escribe a túa resposta"
 #: src/screens/Onboarding/index.tsx:25
 #: src/screens/Onboarding/state.ts:103
 msgid "Writers"
-msgstr "Escritores"
+msgstr "Escritores e escritoras"
 
 #: src/view/com/composer/select-language/SuggestedLanguage.tsx:77
 #: src/view/screens/PreferencesFollowingFeed.tsx:71
@@ -8523,7 +7814,7 @@ msgstr "Si, eliminar este paquete de inicio"
 
 #: src/view/com/util/forms/PostDropdownBtn.tsx:736
 msgid "Yes, detach"
-msgstr ""
+msgstr "Si, desprenderse"
 
 #: src/view/com/util/forms/PostDropdownBtn.tsx:746
 msgid "Yes, hide"
@@ -8531,15 +7822,11 @@ msgstr "Si, ocultar"
 
 #: src/screens/Deactivated.tsx:150
 msgid "Yes, reactivate my account"
-msgstr "Si, volver activar a miña conta"
+msgstr "Si, reactiva a miña conta"
 
 #: src/components/dms/DateDivider.tsx:46
 msgid "Yesterday"
 msgstr "Onte"
-
-#: src/components/dms/MessageItem.tsx:183
-#~ msgid "Yesterday, {time}"
-#~ msgstr "Onte, {time}"
 
 #: src/screens/List/ListHiddenScreen.tsx:140
 msgid "you"
@@ -8555,36 +7842,36 @@ msgstr "Estás en liña."
 
 #: src/view/com/composer/state/video.ts:424
 msgid "You are not allowed to upload videos."
-msgstr "Non tes permiso para subir vídeos."
+msgstr "Non tes permiso para cargar vídeos."
 
 #: src/view/com/profile/ProfileFollows.tsx:95
 msgid "You are not following anyone."
-msgstr "Non estás a seguir a ninguén."
+msgstr "Non estás seguindo a ninguén."
 
 #: src/components/dialogs/nuxs/NeueTypography.tsx:61
 msgid "You can adjust these in your Appearance Settings later."
-msgstr "Podes axustar isto nos axustes de aparencia máis tarde."
+msgstr "Podes axustalos na túa configuración de aparencia máis tarde."
 
 #: src/view/com/posts/FollowingEmptyState.tsx:63
 #: src/view/com/posts/FollowingEndOfFeed.tsx:64
 msgid "You can also discover new Custom Feeds to follow."
-msgstr "Tamén podes descubrir nofas fontes personalizadas para seguir."
+msgstr "Tamén podes descubrir canles personalizadas para seguir."
 
 #: src/view/com/modals/DeleteAccount.tsx:202
-msgid "You can also temporarily deactivate your account instead, and reactivate it at any time."
-msgstr "Tamén podes deshabilitar temporalmente a túa conta e habilitala en calquera momento."
-
-#: src/screens/Onboarding/StepFollowingFeed.tsx:143
-#~ msgid "You can change these settings later."
-#~ msgstr "Podes mudar estes axustes máis tarde."
-
-#: src/components/dms/MessagesNUX.tsx:119
-#~ msgid "You can change this at any time."
-#~ msgstr "Podes mudar isto en calquera momento."
+msgid ""
+"You can also temporarily deactivate your account instead, and reactivate it "
+"at any time."
+msgstr ""
+"Tamén podes desactivar temporalmente a túa conta e reactivala en calquera "
+"momento."
 
 #: src/screens/Messages/Settings.tsx:105
-msgid "You can continue ongoing conversations regardless of which setting you choose."
+msgid ""
+"You can continue ongoing conversations regardless of which setting you "
+"choose."
 msgstr ""
+"Podes continuar as conversas en curso independentemente da configuración "
+"que elixas."
 
 #: src/screens/Login/index.tsx:155
 #: src/screens/Login/PasswordUpdatedForm.tsx:27
@@ -8592,61 +7879,65 @@ msgid "You can now sign in with your new password."
 msgstr "Agora podes iniciar sesión co teu novo contrasinal."
 
 #: src/screens/Deactivated.tsx:136
-msgid "You can reactivate your account to continue logging in. Your profile and posts will be visible to other users."
-msgstr "Podes volver habilitar a túa conta para iniciar sesión. O teu perfil e publicacións serán visíbeis para os outros usuarios."
+msgid ""
+"You can reactivate your account to continue logging in. Your profile and "
+"posts will be visible to other users."
+msgstr ""
+"Podes reactivar a túa conta para continuar iniciando sesión. O teu perfil e "
+"os chíos serán visíbeis para outras persoas."
 
 #: src/view/com/profile/ProfileFollowers.tsx:95
 msgid "You do not have any followers."
-msgstr "Non tes ningún seguidor."
+msgstr "Non tes a ninguén que te siga."
 
 #: src/screens/Profile/KnownFollowers.tsx:100
 msgid "You don't follow any users who follow @{name}."
-msgstr "Non sigues a ningún usuario que sigue a @{name}."
+msgstr "Non segues a ningunha persoa que siga a @{name}."
 
 #: src/view/com/modals/InviteCodes.tsx:67
-msgid "You don't have any invite codes yet! We'll send you some when you've been on Bluesky for a little longer."
-msgstr "Aínda non tes ningún código de convite! Enviarémosche algúns cando leves algo máis de tempo no Bluesky."
+msgid ""
+"You don't have any invite codes yet! We'll send you some when you've been "
+"on Bluesky for a little longer."
+msgstr ""
+"Aínda non tes ningún código de convite! Enviarémosche algúns cando teñas un "
+"pouco máis de tempo en Bluesky."
 
 #: src/view/screens/SavedFeeds.tsx:144
 msgid "You don't have any pinned feeds."
-msgstr "Non tes ningunha fonte fixada."
-
-#: src/view/screens/Feeds.tsx:477
-#~ msgid "You don't have any saved feeds!"
-#~ msgstr "Non tes ningunha fonte gardada!"
+msgstr "Non tes ningunha canle fixada."
 
 #: src/view/screens/SavedFeeds.tsx:184
 msgid "You don't have any saved feeds."
-msgstr "Non tes ningunha fonte gardada."
+msgstr "Non tes canles gardadas."
 
 #: src/view/com/post-thread/PostThread.tsx:214
 msgid "You have blocked the author or you have been blocked by the author."
-msgstr "Bloqueaches ao autor ou fuches bloqueado por el."
+msgstr "Bloqueaches á persoa autora ou fuches bloqueado por ela."
 
 #: src/components/dms/MessagesListBlockedFooter.tsx:58
 msgid "You have blocked this user"
-msgstr "Bloqueaches este usuario"
+msgstr "Bloqueaches a esta persoa"
 
 #: src/components/moderation/ModerationDetailsDialog.tsx:72
 #: src/lib/moderation/useModerationCauseDescription.ts:55
 #: src/lib/moderation/useModerationCauseDescription.ts:63
 msgid "You have blocked this user. You cannot view their content."
-msgstr "Bloqueaches este usuario. Non podes ver o seu contido."
+msgstr "Bloqueaches a esta persoa. Non podes ver o seu contido."
 
 #: src/screens/Login/SetNewPasswordForm.tsx:48
 #: src/screens/Login/SetNewPasswordForm.tsx:85
 #: src/view/com/modals/ChangePassword.tsx:88
 #: src/view/com/modals/ChangePassword.tsx:122
 msgid "You have entered an invalid code. It should look like XXXXX-XXXXX."
-msgstr "Inseriches un código non válido. Debería ter este formato XXXXX-XXXXX."
+msgstr "Introduciches un código non válido. Debería parecer XXXXX-XXXX."
 
 #: src/lib/moderation/useModerationCauseDescription.ts:114
 msgid "You have hidden this post"
-msgstr "Ocultaches esta publicación"
+msgstr "Ocultaches este chío"
 
 #: src/components/moderation/ModerationDetailsDialog.tsx:110
 msgid "You have hidden this post."
-msgstr "Ocultaches esta publicación."
+msgstr "Ocultaches este chío."
 
 #: src/components/moderation/ModerationDetailsDialog.tsx:103
 #: src/lib/moderation/useModerationCauseDescription.ts:97
@@ -8655,48 +7946,60 @@ msgstr "Silenciaches esta conta."
 
 #: src/lib/moderation/useModerationCauseDescription.ts:91
 msgid "You have muted this user"
-msgstr "Silenciaches a este usuario"
+msgstr "Silenciaches esta persoas"
 
 #: src/screens/Messages/ChatList.tsx:223
 msgid "You have no conversations yet. Start one!"
-msgstr "Aínda non tes conversas. Comeza unha!"
+msgstr "Non tes ningunha conversa. Comeza a parolar!"
 
 #: src/view/com/feeds/ProfileFeedgens.tsx:138
 msgid "You have no feeds."
-msgstr "Non tes fontes."
+msgstr "Non tes canles."
 
 #: src/view/com/lists/MyLists.tsx:90
 #: src/view/com/lists/ProfileLists.tsx:134
 msgid "You have no lists."
-msgstr "Non tes listas."
-
-#: src/screens/Messages/List/index.tsx:200
-#~ msgid "You have no messages yet. Start a conversation with someone!"
-#~ msgstr "Aínda non tes ningunha mensaxe. Inicia unha conversa con alguén!"
+msgstr "Non tes listaxes."
 
 #: src/view/screens/ModerationBlockedAccounts.tsx:133
-msgid "You have not blocked any accounts yet. To block an account, go to their profile and select \"Block account\" from the menu on their account."
-msgstr "Aínda non bloqueaches ningunha conta. Para bloquear unha conta, vai ao seu perfil e selecciona \"Bloquear conta\" no menú da conta."
+msgid ""
+"You have not blocked any accounts yet. To block an account, go to their "
+"profile and select \"Block account\" from the menu on their account."
+msgstr ""
+"Aínda non bloqueaches ningunha conta. Para bloquear unha conta, vai ao seu "
+"perfil e selecciona \"Bloquear conta\" no menú da súa conta."
 
 #: src/view/screens/AppPasswords.tsx:96
-msgid "You have not created any app passwords yet. You can create one by pressing the button below."
-msgstr "Aínda non creaches ningún contrasinal de aplicación. Podes crear un premendo o botón de abaixo."
+msgid ""
+"You have not created any app passwords yet. You can create one by pressing "
+"the button below."
+msgstr ""
+"Aínda non creaches ningún contrasinal de aplicación. Podes crear un "
+"premendo o botón de abaixo."
 
 #: src/view/screens/ModerationMutedAccounts.tsx:132
-msgid "You have not muted any accounts yet. To mute an account, go to their profile and select \"Mute account\" from the menu on their account."
-msgstr "Aínda non silenciaches ningunha conta. Para silenciar unha conta, vai ao seu perfil e selecciona \"Silenciar conta\" no menú da conta."
+msgid ""
+"You have not muted any accounts yet. To mute an account, go to their "
+"profile and select \"Mute account\" from the menu on their account."
+msgstr ""
+"Aínda non silenciaches ningunha conta. Para silenciar unha conta, vai ao "
+"seu perfil e selecciona \"Silenciar conta\" no menú da súa conta."
 
 #: src/components/Lists.tsx:52
 msgid "You have reached the end"
-msgstr "Chegaches ao final"
+msgstr "Mimá! Chegaches ao final"
 
 #: src/lib/media/video/upload.shared.ts:56
-msgid "You have temporarily reached the limit for video uploads. Please try again later."
-msgstr "Acadaches temporalmente o límite para subir vídeos. Por favor, téntao máis tarde."
+msgid ""
+"You have temporarily reached the limit for video uploads. Please try again "
+"later."
+msgstr ""
+"Alcanzaches temporalmente o límite de cargas de vídeos. Téntao de novo máis "
+"tarde."
 
 #: src/components/StarterPack/ProfileStarterPacks.tsx:236
 msgid "You haven't created a starter pack yet!"
-msgstr "Aínda non crreaches un paquete de inicio!"
+msgstr "Aínda non creaches un paquete de inicio!"
 
 #: src/components/dialogs/MutedWords.tsx:398
 msgid "You haven't muted any words or tags yet"
@@ -8710,58 +8013,52 @@ msgstr "Ocultaches esta resposta."
 #: src/components/moderation/LabelsOnMeDialog.tsx:78
 msgid "You may appeal non-self labels if you feel they were placed in error."
 msgstr ""
+"Podes apelar as etiquetas non propias se consideras que se colocaron por "
+"erro."
 
 #: src/components/moderation/LabelsOnMeDialog.tsx:83
 msgid "You may appeal these labels if you feel they were placed in error."
-msgstr "Podes apelar estas etiquetas se cres que foron colocadas por un erro."
+msgstr "Podes apelar estas etiquetas se consideras que se colocaron por erro."
 
 #: src/screens/StarterPack/Wizard/State.tsx:79
 msgid "You may only add up to {STARTER_PACK_MAX_SIZE} profiles"
-msgstr "Só podes engadir até {STARTER_PACK_MAX_SIZE} perfís"
+msgstr "Só podes engadir ata {STARTER_PACK_MAX_SIZE} perfís"
 
 #: src/screens/StarterPack/Wizard/State.tsx:97
 msgid "You may only add up to 3 feeds"
-msgstr "Só podes engadir até 3 fontes"
-
-#: src/screens/StarterPack/Wizard/State.tsx:95
-#~ msgid "You may only add up to 50 feeds"
-#~ msgstr "Só podes engadir até 50 fontes"
-
-#: src/screens/StarterPack/Wizard/State.tsx:78
-#~ msgid "You may only add up to 50 profiles"
-#~ msgstr "Só podes engadir até 50 perfís"
+msgstr "Só podes engadir ata 3 canles"
 
 #: src/lib/media/picker.shared.ts:22
 msgid "You may only select up to 4 images"
-msgstr "Só podes seleccionar até 4 imaxes"
+msgstr "Só podes seleccionar ata 4 imaxes"
 
 #: src/screens/Signup/StepInfo/Policies.tsx:106
 msgid "You must be 13 years of age or older to sign up."
-msgstr "Debes tes como mínimo 13 anos para rexistrarte."
-
-#: src/screens/Onboarding/StepModeration/AdultContentEnabledPref.tsx:110
-#~ msgid "You must be 18 years or older to enable adult content"
-#~ msgstr "Debes ser maior de 18 anos para habilitar o contido para adultos"
+msgstr "Debes ter 13 anos ou máis para rexistrarte."
 
 #: src/components/StarterPack/ProfileStarterPacks.tsx:307
-msgid "You must be following at least seven other people to generate a starter pack."
-msgstr "Debes seguir polo menos outras sete persoas para xerar un paquete de inicio."
+msgid ""
+"You must be following at least seven other people to generate a starter "
+"pack."
+msgstr ""
+"Debes seguir polo menos a outras sete persoas para xerar un paquete de "
+"inicio."
 
 #: src/components/StarterPack/QrCodeDialog.tsx:60
 msgid "You must grant access to your photo library to save a QR code"
-msgstr "Tes de conceder permiso á túa biblioteca de fotos para gardar o código QR"
+msgstr "Debes conceder acceso á túa biblioteca de fotos para gardar un código QR"
 
 #: src/components/StarterPack/ShareDialog.tsx:69
 msgid "You must grant access to your photo library to save the image."
-msgstr "Tes de conceder permiso á túa biblioteca de fotos para gardar a imaxe."
+msgstr "Debes conceder acceso á túa biblioteca de fotos para gardar a imaxe."
 
 #: src/components/ReportDialog/SubmitView.tsx:210
 msgid "You must select at least one labeler for a report"
-msgstr ""
+msgstr "Debes seleccionar polo menos unha etiquetadora para un informe"
 
 #: src/screens/Deactivated.tsx:131
 msgid "You previously deactivated @{0}."
-msgstr "Desactivaches @{0} anteriormente."
+msgstr "Anteriormente desactivaches a @{0}."
 
 #: src/view/com/util/forms/PostDropdownBtn.tsx:222
 msgid "You will no longer receive notifications for this thread"
@@ -8772,8 +8069,13 @@ msgid "You will now receive notifications for this thread"
 msgstr "Agora recibirás notificacións deste fío"
 
 #: src/screens/Login/SetNewPasswordForm.tsx:98
-msgid "You will receive an email with a \"reset code.\" Enter that code here, then enter your new password."
-msgstr "Recibirás un correo cun \"código de restauración.\" Insire ese código aquí, e logo o teu novo contrasinal."
+msgid ""
+"You will receive an email with a \"reset code.\" Enter that code here, then "
+"enter your new password."
+msgstr ""
+"Recibirás un correo electrónico cun \"código de restablecemento\". "
+"Introduce ese código aquí e, a continuación, introduce o teu novo "
+"contrasinal."
 
 #: src/screens/Messages/components/ChatListItem.tsx:124
 msgid "You: {0}"
@@ -8788,64 +8090,72 @@ msgid "You: {short}"
 msgstr "Ti: {short}"
 
 #: src/screens/Signup/index.tsx:107
-msgid "You'll follow the suggested users and feeds once you finish creating your account!"
-msgstr "Seguirás os usuarios e fontes suxeridos unha vez rematada a creación da túa conta!"
+msgid ""
+"You'll follow the suggested users and feeds once you finish creating your "
+"account!"
+msgstr ""
+"Seguirás a máis persoas e as súas canles suxeridas unha vez remates de "
+"crear a túa conta!"
 
 #: src/screens/Signup/index.tsx:112
 msgid "You'll follow the suggested users once you finish creating your account!"
-msgstr "Seguirás os usuarios suxeridos unha vez rematada a creación da túa conta!"
+msgstr "Seguirás a persoas suxeridas unha vez remates de crear a túa conta! "
 
 #: src/screens/StarterPack/StarterPackLandingScreen.tsx:232
 msgid "You'll follow these people and {0} others"
-msgstr "Seguirás estas persoas e outras {0}"
+msgstr "Seguirás a estas persoas e a {0} máis"
 
 #: src/screens/StarterPack/StarterPackLandingScreen.tsx:230
 msgid "You'll follow these people right away"
-msgstr "Seguirás estas persoas agora"
+msgstr "Seguirás a estas persoas de inmediato"
 
 #: src/components/dialogs/VerifyEmailDialog.tsx:138
 msgid "You'll receive an email at <0>{0}</0> to verify it's you."
-msgstr "Recibirás un correo en <0>{0}</0> para verificar que es ti."
+msgstr "Recibirás un correo electrónico en <0>{0}</0> para verificar que es ti. "
 
 #: src/screens/StarterPack/StarterPackLandingScreen.tsx:270
 msgid "You'll stay updated with these feeds"
-msgstr ""
-
-#: src/screens/Onboarding/StepModeration/index.tsx:60
-#~ msgid "You're in control"
-#~ msgstr "Ti tes o control"
+msgstr "Manteraste á última con estas canles"
 
 #: src/screens/SignupQueued.tsx:93
 #: src/screens/SignupQueued.tsx:94
 #: src/screens/SignupQueued.tsx:109
 msgid "You're in line"
-msgstr "Estás na cola"
+msgstr "Estás en liña"
 
 #: src/screens/Deactivated.tsx:89
 #: src/screens/Settings/components/DeactivateAccountDialog.tsx:54
-msgid "You're logged in with an App Password. Please log in with your main password to continue deactivating your account."
-msgstr "Iniciaches sesión cun contrasinal de aplicación. Por favor, inicia sesión co teu contrasinal principal para poder deshabilitar a túa conta."
+msgid ""
+"You're logged in with an App Password. Please log in with your main "
+"password to continue deactivating your account."
+msgstr ""
+"Iniciaches sesión cun contrasinal da aplicación. Inicia sesión co teu "
+"contrasinal principal para continuar desactivando a túa conta."
 
 #: src/screens/Onboarding/StepFinished.tsx:226
 msgid "You're ready to go!"
-msgstr "Xa podes comezar!"
+msgstr "Prepárate que imos!"
 
 #: src/components/moderation/ModerationDetailsDialog.tsx:107
 #: src/lib/moderation/useModerationCauseDescription.ts:106
 msgid "You've chosen to hide a word or tag within this post."
-msgstr "Escolliches ocultar unha palabra ou etiqueta dentro desta publicación."
+msgstr "Escolleches ocultar unha palabra ou etiqueta dentro deste chío."
 
 #: src/view/com/posts/FollowingEndOfFeed.tsx:44
 msgid "You've reached the end of your feed! Find some more accounts to follow."
-msgstr "Acadaches o final da túa fonte! Procura máis contas para seguir."
+msgstr "Chegaches ao final das túas canles! Busca máis contas que seguir."
 
 #: src/view/com/composer/state/video.ts:435
 msgid "You've reached your daily limit for video uploads (too many bytes)"
-msgstr "Acadaches o límite diario para subir vídeos (demasidos bytes)"
+msgstr ""
+"Chegaches ao teu límite diario de carga de vídeos (demasiados bytes por "
+"hoxe)"
 
 #: src/view/com/composer/state/video.ts:439
 msgid "You've reached your daily limit for video uploads (too many videos)"
-msgstr "Acadaches o límite diario para subir vídeos (demasiados vídeos)"
+msgstr ""
+"Chegaches ao teu límite diario de carga de vídeos (demasiados vídeos por "
+"hoxe)"
 
 #: src/screens/Signup/index.tsx:140
 msgid "Your account"
@@ -8853,66 +8163,85 @@ msgstr "A túa conta"
 
 #: src/view/com/modals/DeleteAccount.tsx:88
 msgid "Your account has been deleted"
-msgstr "A túa conta foi eliminada"
+msgstr "A túa conta foi eliminada."
 
 #: src/view/com/composer/state/video.ts:443
 msgid "Your account is not yet old enough to upload videos. Please try again later."
-msgstr "A túa conta non é vella abondo para subir vídeos. Por favor, téntao máis tarde."
+msgstr ""
+"A túa conta aínda non ten suficiente antigüidade para subir vídeos. Por "
+"favor, inténtao de novo máis tarde."
 
 #: src/view/screens/Settings/ExportCarDialog.tsx:64
-msgid "Your account repository, containing all public data records, can be downloaded as a \"CAR\" file. This file does not include media embeds, such as images, or your private data, which must be fetched separately."
-msgstr "O repositorio da túa conta, que contén todos os rexistros de datos públicos, pódese descargar coma ficheiro \"CAR\". Este ficheiro non inclúe a media incrustada, como imaxes ou datos privados que teñen que ser obtidos por separado."
+msgid ""
+"Your account repository, containing all public data records, can be "
+"downloaded as a \"CAR\" file. This file does not include media embeds, such "
+"as images, or your private data, which must be fetched separately."
+msgstr ""
+"O repositorio da túa conta, que contén todos os rexistros de datos público, "
+"pode ser descargado como un ficheiro \"CAR\". Este ficheiro non inclúe "
+"ficheiros multimedia incrustados, como imaxes nin os teus datos privados, "
+"que deben ser obtidos por separado."
 
 #: src/screens/Signup/StepInfo/index.tsx:211
 msgid "Your birth date"
 msgstr "A túa data de nacemento"
 
 #: src/view/com/util/post-embeds/VideoEmbed.web.tsx:171
-msgid "Your browser does not support the video format. Please try a different browser."
-msgstr "O teu navegador non soporta este formato de vídeo. Por favor, emprega outro navegador."
+msgid ""
+"Your browser does not support the video format. Please try a different "
+"browser."
+msgstr ""
+"O teu navegador non soporta este formato de vídeo. Por favor, proba cun "
+"diferente."
 
 #: src/screens/Messages/components/ChatDisabled.tsx:25
 msgid "Your chats have been disabled"
-msgstr "As túas conversas foron deshabilitadas"
+msgstr "As túas conversas foron deshabilitadas."
 
 #: src/view/com/modals/InAppBrowserConsent.tsx:44
 msgid "Your choice will be saved, but can be changed later in settings."
-msgstr "A túa escolla será gardada, mais pode ser cambiada máis tarde nos axustes."
-
-#: src/screens/Onboarding/StepFollowingFeed.tsx:62
-#~ msgid "Your default feed is \"Following\""
-#~ msgstr "A túa fonte predefinida é \"Seguindo\""
+msgstr "A túa elección gardarase, mais pódese cambiar máis tarde na configuración."
 
 #: src/screens/Login/ForgotPasswordForm.tsx:51
 #: src/screens/Signup/state.ts:203
 #: src/screens/Signup/StepInfo/index.tsx:108
 #: src/view/com/modals/ChangePassword.tsx:55
 msgid "Your email appears to be invalid."
-msgstr "O teu correo semella non ser válido."
+msgstr "O teu enderezo electrónico parece non ser válido."
 
 #: src/view/com/modals/ChangeEmail.tsx:120
-msgid "Your email has been updated but not verified. As a next step, please verify your new email."
-msgstr "O teu correo foi actualizado mais non foi verificado. Como seguinte paso, por favor verifica o teu novo correo."
+msgid ""
+"Your email has been updated but not verified. As a next step, please verify "
+"your new email."
+msgstr ""
+"O teu enderezo electrónico foi actualizado mais non verificado. Verifica o "
+"teu novo enderezo electrónico."
 
 #: src/view/com/modals/VerifyEmail.tsx:122
-msgid "Your email has not yet been verified. This is an important security step which we recommend."
-msgstr "O teu correo aínda non foi verificado. Este é un paso na seguranza importante e que recomendamos."
+msgid ""
+"Your email has not yet been verified. This is an important security step "
+"which we recommend."
+msgstr ""
+"O teu enderezo electrónico aínda non foi verificado. Pola túa seguridade, "
+"recomendámosche que o verifiques."
 
 #: src/state/shell/progress-guide.tsx:156
 msgid "Your first like!"
-msgstr "O teu primeiro Gústame!"
+msgstr "O teu primeiro gústame!"
 
 #: src/view/com/posts/FollowingEmptyState.tsx:43
 msgid "Your following feed is empty! Follow more users to see what's happening."
-msgstr "A túa fonte inical está baleira! Segue a máis xente para saber que acontece."
+msgstr ""
+"A seguinte canle está baleira! Sigue a máis persoas para ver o que está a "
+"acontecer."
 
 #: src/screens/Signup/StepHandle.tsx:125
 msgid "Your full handle will be"
-msgstr "O teu nome de usuario completo será"
+msgstr "O teu alcume completo será"
 
 #: src/view/com/modals/ChangeHandle.tsx:258
 msgid "Your full handle will be <0>@{0}</0>"
-msgstr "O teu nome de usuario completo será <0>@{0}</0>"
+msgstr "O teu alcume será <0>@{0}</0> "
 
 #: src/components/dialogs/MutedWords.tsx:369
 msgid "Your muted words"
@@ -8920,23 +8249,30 @@ msgstr "As túas palabras silenciadas"
 
 #: src/view/com/modals/ChangePassword.tsx:158
 msgid "Your password has been changed successfully!"
-msgstr "O teu contrasinal foi cambiado con éxito!"
+msgstr "O teu contrasinal cambiouse correctamente."
 
 #: src/view/com/composer/Composer.tsx:405
 msgid "Your post has been published"
-msgstr "A túa publicación foi publicada"
+msgstr "Chío publicado"
 
 #: src/screens/Onboarding/StepFinished.tsx:241
 msgid "Your posts, likes, and blocks are public. Mutes are private."
-msgstr "As túas publicacións, o que che gusta e a quen bloqueas son públicos. Ninguén pode ver a quen silencias."
+msgstr ""
+"Os teus chíos, o que che gusta e a quen bloqueas son públicos. Ninguén pode "
+"ver a quen silencias."
 
 #: src/view/screens/Settings/index.tsx:119
 msgid "Your profile"
 msgstr "O teu perfil"
 
 #: src/screens/Settings/components/DeactivateAccountDialog.tsx:75
-msgid "Your profile, posts, feeds, and lists will no longer be visible to other Bluesky users. You can reactivate your account at any time by logging in."
-msgstr "O teu perfil, publicacións, fontes e listas xa non serán visíbeis para os outros usuarios. Podes volver activar a túa conta en calquera momento ao iniciar sesión."
+msgid ""
+"Your profile, posts, feeds, and lists will no longer be visible to other "
+"Bluesky users. You can reactivate your account at any time by logging in."
+msgstr ""
+"O teu perfil, chíos, canles e listaxes non estarán visíbeis para outras "
+"persoas de Bluesky. Podes reactivar a túa conta en calquera momento "
+"iniciando sesión."
 
 #: src/view/com/composer/Composer.tsx:404
 msgid "Your reply has been published"
@@ -8944,8 +8280,1278 @@ msgstr "Resposta publicada"
 
 #: src/components/dms/ReportDialog.tsx:157
 msgid "Your report will be sent to the Bluesky Moderation Service"
-msgstr "A túa denuncia enviarase ao servizo de moderación do Bluesky"
+msgstr "O teu informe enviarase ao Servizo de moderación de Bluesky"
 
 #: src/screens/Signup/index.tsx:142
 msgid "Your user handle"
-msgstr "O teu nome de usuario"
+msgstr "O teu alcume"
+
+#: src/screens/StarterPack/Wizard/index.tsx:475
+msgctxt "profiles"
+msgid ""
+"<0>{0}, </0><1>{1}, </1>and {2, plural, one {# other} other {# others}} are "
+"included in your starter pack"
+msgstr ""
+"<0>{0}, </0><1>{1}, </1>e {2, plural, un {# outro} outro {# outros}} foron "
+"incluídos no teu paquete\n"
+
+#: src/screens/StarterPack/Wizard/index.tsx:528
+msgctxt "feeds"
+msgid ""
+"<0>{0}, </0><1>{1}, </1>and {2, plural, one {# other} other {# others}} are "
+"included in your starter pack"
+msgstr ""
+"<0>{0}, </0><1>{1}, </1>e {2, plural, one {# other} other {# others}} "
+"inclúense no teu paquete de inicio"
+
+#: src/view/com/modals/CreateOrEditList.tsx:340
+#: src/view/com/modals/DeleteAccount.tsx:174
+#: src/view/com/modals/DeleteAccount.tsx:296
+msgctxt "action"
+msgid "Cancel"
+msgstr "Cancelar"
+
+#: src/view/screens/Settings/index.tsx:342
+msgctxt "action"
+msgid "Change"
+msgstr "Cambiar"
+
+#: src/view/com/modals/ListAddRemoveUsers.tsx:145
+#: src/view/com/modals/UserAddRemoveLists.tsx:113
+#: src/view/com/modals/UserAddRemoveLists.tsx:116
+msgctxt "action"
+msgid "Done"
+msgstr "Listo"
+
+#: src/view/com/lists/ListMembers.tsx:146
+msgctxt "action"
+msgid "Edit"
+msgstr "Editar"
+
+#: src/view/com/profile/FollowButton.tsx:70
+msgctxt "action"
+msgid "Follow"
+msgstr "Seguir"
+
+#: src/view/com/profile/FollowButton.tsx:79
+msgctxt "action"
+msgid "Follow Back"
+msgstr "Seguir de volta"
+
+#: src/view/com/notifications/FeedItem.tsx:477
+msgctxt "action"
+msgid "Hide"
+msgstr "Ocultar"
+
+#: src/view/screens/Lists.tsx:84
+msgctxt "action"
+msgid "New"
+msgstr "Novo"
+
+#: src/view/com/feeds/FeedPage.tsx:143
+msgctxt "action"
+msgid "New post"
+msgstr "Novo chío"
+
+#: src/view/shell/desktop/LeftNav.tsx:311
+msgctxt "action"
+msgid "New Post"
+msgstr "Novo Chío"
+
+#: src/view/com/composer/Composer.tsx:710
+#: src/view/com/composer/Composer.tsx:717
+msgctxt "action"
+msgid "Post"
+msgstr "Chiar"
+
+#: src/view/com/composer/Composer.tsx:708
+msgctxt "action"
+msgid "Reply"
+msgstr "Responder"
+
+#: src/view/com/util/post-ctrls/RepostButton.tsx:72
+#: src/view/com/util/post-ctrls/RepostButton.tsx:103
+#: src/view/com/util/post-ctrls/RepostButton.tsx:119
+msgctxt "action"
+msgid "Repost"
+msgstr "Rechouchiar"
+
+#: src/view/com/lightbox/Lightbox.tsx:167
+#: src/view/com/modals/CreateOrEditList.tsx:325
+msgctxt "action"
+msgid "Save"
+msgstr "Gardar"
+
+#: src/view/com/modals/DeleteAccount.tsx:162
+msgctxt "action"
+msgid "Send Email"
+msgstr "Enviar correo"
+
+#: src/view/com/lightbox/Lightbox.tsx:176
+msgctxt "action"
+msgid "Share"
+msgstr "Compartir"
+
+#: src/view/com/util/error/ErrorScreen.tsx:82
+msgctxt "action"
+msgid "Try again"
+msgstr "Intentar de novo"
+
+#: src/screens/Profile/Header/ProfileHeaderStandard.tsx:192
+msgctxt "action"
+msgid "Unblock"
+msgstr "Desbloquear"
+
+#: src/view/com/profile/FollowButton.tsx:61
+msgctxt "action"
+msgid "Unfollow"
+msgstr "Deixar de seguir"
+
+#: src/view/com/posts/FeedItem.tsx:273
+msgctxt "from-feed"
+msgid "From <0/>"
+msgstr "De <0/>"
+
+#: src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerNative.tsx:157
+#: src/view/com/util/post-embeds/VideoEmbedInner/web-controls/VolumeControl.tsx:94
+msgctxt "video"
+msgid "Mute"
+msgstr "Silenciar"
+
+#: src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerNative.tsx:156
+#: src/view/com/util/post-embeds/VideoEmbedInner/web-controls/VolumeControl.tsx:93
+msgctxt "video"
+msgid "Unmute"
+msgstr "Activar"
+
+#: src/view/com/post-thread/PostThread.tsx:481
+msgctxt "description"
+msgid "Post"
+msgstr "Chío"
+
+#: src/view/com/post/Post.tsx:195
+#: src/view/com/posts/FeedItem.tsx:544
+msgctxt "description"
+msgid "Reply to <0><1/></0>"
+msgstr "Responder a <0><1/></0>"
+
+#: src/view/com/posts/FeedItem.tsx:535
+msgctxt "description"
+msgid "Reply to a blocked post"
+msgstr "Responder a un chío bloqueado"
+
+#: src/view/com/posts/FeedItem.tsx:537
+msgctxt "description"
+msgid "Reply to a post"
+msgstr "Responder a un chío"
+
+#: src/view/com/post/Post.tsx:193
+#: src/view/com/posts/FeedItem.tsx:541
+msgctxt "description"
+msgid "Reply to you"
+msgstr "Responderche"
+
+#: src/components/moderation/LabelsOnMe.tsx:55
+#~ msgid ""
+#~ "{0, plural, one {# label has been placed on this account} other {# labels "
+#~ "has been placed on this account}}"
+#~ msgstr ""
+
+#: src/components/moderation/LabelsOnMe.tsx:61
+#~ msgid ""
+#~ "{0, plural, one {# label has been placed on this content} other {# labels "
+#~ "has been placed on this content}}"
+#~ msgstr ""
+
+#: src/components/KnownFollowers.tsx:179
+#~ msgid "{0, plural, one {and # other} other {and # others}}"
+#~ msgstr ""
+
+#: src/view/screens/ProfileList.tsx:286
+#~ msgid "{0} your feeds"
+#~ msgstr "{0} os teus feeds"
+
+#: src/lib/hooks/useTimeAgo.ts:69
+#~ msgid "{diff, plural, one {day} other {days}}"
+#~ msgstr ""
+
+#: src/lib/hooks/useTimeAgo.ts:64
+#~ msgid "{diff, plural, one {hour} other {hours}}"
+#~ msgstr ""
+
+#: src/lib/hooks/useTimeAgo.ts:59
+#~ msgid "{diff, plural, one {minute} other {minutes}}"
+#~ msgstr ""
+
+#: src/lib/hooks/useTimeAgo.ts:75
+#~ msgid "{diff, plural, one {month} other {months}}"
+#~ msgstr ""
+
+#: src/lib/hooks/useTimeAgo.ts:54
+#~ msgid "{diffSeconds, plural, one {second} other {seconds}}"
+#~ msgstr ""
+
+#: src/view/screens/PreferencesFollowingFeed.tsx:67
+#~ msgid ""
+#~ "{value, plural, =0 {Show all replies} one {Show replies with at least # "
+#~ "like} other {Show replies with at least # likes}}"
+#~ msgstr ""
+
+#: src/components/WhoCanReply.tsx:296
+#~ msgid "<0/> members"
+#~ msgstr "<0/> membros"
+
+#: src/screens/StarterPack/Wizard/index.tsx:485
+#~ msgid "<0>{0} </0>and<1> </1><2>{1} </2>are included in your starter pack"
+#~ msgstr ""
+
+#: src/screens/StarterPack/Wizard/index.tsx:497
+#~ msgid ""
+#~ "<0>{0}, </0><1>{1}, </1>and {2} {3, plural, one {other} other {others}} are "
+#~ "included in your starter pack"
+#~ msgstr ""
+
+#: src/view/shell/Drawer.tsx:96
+#~ msgid "<0>{0}</0> following"
+#~ msgstr "<0>{0}</0> seguindo"
+
+#: src/components/ProfileHoverCard/index.web.tsx:437
+#~ msgid "<0>{followers} </0><1>{pluralizedFollowers}</1>"
+#~ msgstr ""
+
+#: src/components/ProfileHoverCard/index.web.tsx:449
+#: src/screens/Profile/Header/Metrics.tsx:45
+#~ msgid "<0>{following} </0><1>following</1>"
+#~ msgstr "<0>{following} </0><1>seguindo</1>"
+
+#: src/view/com/modals/SelfLabel.tsx:135
+#~ msgid ""
+#~ "<0>Not Applicable.</0> This warning is only available for posts with media "
+#~ "attached."
+#~ msgstr ""
+
+#: src/tours/Tooltip.tsx:70
+#~ msgid "A help tooltip"
+#~ msgstr ""
+
+#: src/components/moderation/LabelsOnMe.tsx:42
+#~ msgid "account"
+#~ msgstr "conta"
+
+#: src/view/com/composer/GifAltText.tsx:175
+#~ msgid "Add ALT text"
+#~ msgstr "Engadir texto alternativo"
+
+#: src/screens/StarterPack/Wizard/index.tsx:197
+#~ msgid "Add people to your starter pack that you think others will enjoy following"
+#~ msgstr ""
+
+#: src/view/screens/PreferencesFollowingFeed.tsx:171
+#~ msgid "Adjust the number of likes a reply must have to be shown in your feed."
+#~ msgstr ""
+#~ "Ajusta a cantidad de me gusta que una resposta debe tener para aparecer en "
+#~ "tu feed."
+
+#: src/screens/Messages/Settings.tsx:61
+#: src/screens/Messages/Settings.tsx:64
+#~ msgid "Allow messages from"
+#~ msgstr ""
+
+#: src/components/dialogs/GifSelect.tsx:252
+#~ msgid "An error occured"
+#~ msgstr "Ocurriu un erro"
+
+#: src/components/dialogs/nuxs/TenMillion/index.tsx:250
+#~ msgid "An error occurred while saving the image!"
+#~ msgstr ""
+
+#: src/components/StarterPack/ShareDialog.tsx:79
+#~ msgid "An error occurred while saving the image."
+#~ msgstr ""
+
+#: src/components/dms/MessageMenu.tsx:134
+#~ msgid "An error occurred while trying to delete the message. Please try again."
+#~ msgstr "Ocurriu un erro ao tentar eliminar a mensaxe. Téntao de novo."
+
+#: src/components/moderation/LabelsOnMeDialog.tsx:193
+#~ msgid "Appeal submitted."
+#~ msgstr "Apelación enviada"
+
+#: src/screens/StarterPack/StarterPackScreen.tsx:610
+#~ msgid "Are you sure you want delete this starter pack?"
+#~ msgstr ""
+
+#: src/components/dms/MessageMenu.tsx:123
+#~ msgid ""
+#~ "Are you sure you want to delete this message? The message will be deleted "
+#~ "for you, but not for other participants."
+#~ msgstr ""
+#~ "Seguro que queres eliminar esta mensaxe? A mensaje será eliminada para ti, "
+#~ "pero non para outras persoas participantes."
+
+#: src/components/dms/ConvoMenu.tsx:189
+#~ msgid ""
+#~ "Are you sure you want to leave this conversation? Your messages will be "
+#~ "deleted for you, but not for other participants."
+#~ msgstr ""
+#~ "Estás seguro/a de que queres eliminar esta conversa? Eliminarase para ti, "
+#~ "pero non para as outras persoas participantes."
+
+#: src/screens/Onboarding/StepSuggestedAccounts/index.tsx:144
+#~ msgid "Based on your interest in {interestsText}"
+#~ msgstr "Basado en tus intereses en {interestsText}"
+
+#: src/view/com/auth/server-input/index.tsx:154
+#~ msgid ""
+#~ "Bluesky is an open network where you can choose your hosting provider. "
+#~ "Custom hosting is now available in beta for developers."
+#~ msgstr ""
+#~ "Bluesky es una red abierta donde puedes elegir un proveedor de servicio. "
+#~ "Servicios personalizados ya están disponibles en beta para desarrolladores."
+
+#: src/components/dialogs/nuxs/TenMillion/index.tsx:206
+#~ msgid "Bluesky now has over 10 million users, and I was #{0}!"
+#~ msgstr ""
+
+#: src/components/dialogs/nuxs/TenMillion/index.tsx:614
+#~ msgid "Brag a little!"
+#~ msgstr ""
+
+#: src/screens/Onboarding/StepAlgoFeeds/FeedCard.tsx:112
+#~ msgid "by @{0}"
+#~ msgstr "por @{0}"
+
+#: src/screens/Signup/StepInfo/Policies.tsx:80
+#~ msgid "By creating an account you agree to the {els}."
+#~ msgstr "Ao crear unha conta, aceptas os nosos {els}."
+
+#: src/view/com/modals/EditProfile.tsx:239
+#~ msgid "Cancel profile editing"
+#~ msgstr "Cancelar edición de perfil"
+
+#: src/components/dialogs/nuxs/TenMillion/index.tsx:368
+#~ msgid "Celebrating {0} users"
+#~ msgstr ""
+
+#: src/view/com/modals/Threadgate.tsx:75
+#~ msgid "Choose \"Everybody\" or \"Nobody\""
+#~ msgstr "Elixe \"Todos\" ou \"Ninguén\""
+
+#: src/screens/Onboarding/StepInterests/index.tsx:191
+#~ msgid "Choose 3 or more:"
+#~ msgstr ""
+
+#: src/screens/Onboarding/StepInterests/index.tsx:326
+#~ msgid "Choose at least {0} more"
+#~ msgstr ""
+
+#: src/components/dialogs/ThreadgateEditor.tsx:91
+#: src/components/dialogs/ThreadgateEditor.tsx:95
+#~ msgid "Choose who can reply"
+#~ msgstr ""
+
+#: src/screens/Onboarding/StepAlgoFeeds/index.tsx:104
+#~ msgid "Choose your main feeds"
+#~ msgstr "Elige tus feeds principales"
+
+#: src/view/screens/Settings/index.tsx:912
+#~ msgid "Clear all legacy storage data"
+#~ msgstr "Borrar todos os datos de almacenamiento heredados"
+
+#: src/view/screens/Settings/index.tsx:915
+#~ msgid "Clear all legacy storage data (restart after this)"
+#~ msgstr ""
+#~ "Borrar todos os datos de almacenamiento heredados (reiniciar después de "
+#~ "esto)"
+
+#: src/view/screens/Settings/index.tsx:913
+#~ msgid "Clears all legacy storage data"
+#~ msgstr ""
+
+#: src/screens/Feeds/NoFollowingFeed.tsx:46
+#~ msgid "Click here to add one."
+#~ msgstr "Clic aquí para agregar un."
+
+#: src/components/dms/MessagesNUX.tsx:162
+#~ msgid "Close modal"
+#~ msgstr ""
+
+#: src/view/com/composer/Composer.tsx:552
+#~ msgid "Closes post composer and discards post draft"
+#~ msgstr "Pecha o compositor de post e descarta borrador"
+
+#: src/view/com/composer/videos/VideoTranscodeProgress.tsx:51
+#~ msgid "Compressing..."
+#~ msgstr "Comprimindo..."
+
+#: src/screens/Onboarding/StepModeration/ModerationOption.tsx:81
+#~ msgid "Configure content filtering setting for category: {0}"
+#~ msgstr ""
+
+#: src/components/moderation/LabelsOnMe.tsx:42
+#~ msgid "content"
+#~ msgstr ""
+
+#: src/screens/Onboarding/StepAlgoFeeds/index.tsx:158
+#~ msgid "Continue to the next step"
+#~ msgstr ""
+
+#: src/screens/Onboarding/StepSuggestedAccounts/index.tsx:199
+#~ msgid "Continue to the next step without following any accounts"
+#~ msgstr ""
+
+#: src/view/com/composer/videos/state.ts:31
+#~ msgid "Could not compress video"
+#~ msgstr "Non se pode comprimir o video"
+
+#: src/components/dms/NewChat.tsx:241
+#~ msgid "Could not load profiles. Please try again later."
+#~ msgstr "No se pudo cargar os perfiles. Intente de nuevo luego."
+
+#: src/components/dms/ConvoMenu.tsx:68
+#~ msgid "Could not unmute chat"
+#~ msgstr "No se pudo desmutear o chat"
+
+#: src/view/com/auth/SplashScreen.tsx:57
+#: src/view/com/auth/SplashScreen.web.tsx:106
+#~ msgid "Create a new account"
+#~ msgstr "Crear unha conta nova"
+
+#: src/components/StarterPack/ShareDialog.tsx:158
+#~ msgid "Create QR code"
+#~ msgstr "Crea un código QR"
+
+#: src/view/screens/Settings/index.tsx:473
+#~ msgid "Dark Theme"
+#~ msgstr ""
+
+#: src/view/com/modals/DeleteAccount.tsx:87
+#~ msgid "Delete Account"
+#~ msgstr "Borrar a conta"
+
+#: src/components/dms/MessagesNUX.tsx:88
+#~ msgid "Direct messages are here!"
+#~ msgstr ""
+
+#: src/view/screens/AccessibilitySettings.tsx:111
+#~ msgid "Disable autoplay for GIFs"
+#~ msgstr "Non reproducir GIFs automáticamente"
+
+#: src/tours/HomeTour.tsx:70
+#~ msgid "Discover learns which posts you like as you browse."
+#~ msgstr ""
+
+#: src/view/com/modals/EditProfile.tsx:175
+#~ msgid "Display Name"
+#~ msgstr "Mostrar o nombre"
+
+#: src/components/dialogs/nuxs/TenMillion/index.tsx:622
+#~ msgid "Download image"
+#~ msgstr ""
+
+#: src/screens/Onboarding/StepModeration/AdultContentEnabledPref.tsx:120
+#~ msgid ""
+#~ "Due to Apple policies, adult content can only be enabled on the web after "
+#~ "completing sign up."
+#~ msgstr ""
+
+#: src/view/com/modals/EditProfile.tsx:180
+#~ msgid "e.g. Alice Roberts"
+#~ msgstr "p. ej. Alicia Roberts"
+
+#: src/view/com/modals/EditProfile.tsx:198
+#~ msgid "e.g. Artist, dog-lover, and avid reader."
+#~ msgstr "p. ej. Artista, amante dos e ávida lectora."
+
+#: src/view/com/modals/EditProfile.tsx:147
+#~ msgid "Edit my profile"
+#~ msgstr "Editar o meu perfil"
+
+#: src/view/com/home/HomeHeaderLayout.web.tsx:76
+#: src/view/screens/Feeds.tsx:416
+#~ msgid "Edit Saved Feeds"
+#~ msgstr "Editar os Meus Fíos Gardados"
+
+#: src/view/com/modals/EditProfile.tsx:188
+#~ msgid "Edit your display name"
+#~ msgstr "Editar tu nombre para mostrar "
+
+#: src/view/com/modals/EditProfile.tsx:206
+#~ msgid "Edit your profile description"
+#~ msgstr "Edita tu descripcion de perfil"
+
+#: src/components/dialogs/ThreadgateEditor.tsx:98
+#~ msgid "Either choose \"Everybody\" or \"Nobody\""
+#~ msgstr ""
+
+#: src/screens/Onboarding/StepModeration/AdultContentEnabledPref.tsx:94
+#~ msgid "Enable Adult Content"
+#~ msgstr ""
+
+#: src/screens/Onboarding/StepModeration/AdultContentEnabledPref.tsx:78
+#: src/screens/Onboarding/StepModeration/AdultContentEnabledPref.tsx:79
+#~ msgid "Enable adult content in your feeds"
+#~ msgstr ""
+
+#: src/view/screens/PreferencesFollowingFeed.tsx:145
+#~ msgid "Enable this setting to only see replies between people you follow."
+#~ msgstr ""
+#~ "Activa esta opción para ver sólo las respostas de las personas a las que "
+#~ "sigues."
+
+#: src/components/Lists.tsx:52
+#~ msgid "End of list"
+#~ msgstr ""
+
+#: src/tours/Tooltip.tsx:159
+#~ msgid ""
+#~ "End of onboarding tour window. Do not move forward. Instead, go backward "
+#~ "for more options, or press to skip."
+#~ msgstr ""
+
+#: src/screens/Messages/Conversation/MessageListError.tsx:28
+#~ msgid "Failed to load past messages."
+#~ msgstr ""
+
+#: src/screens/Messages/Conversation/MessageListError.tsx:29
+#~ msgid "Failed to send message(s)."
+#~ msgstr "Error ao enviar mensaje(s)"
+
+#: src/view/screens/Feeds.tsx:709
+#~ msgid "Feed offline"
+#~ msgstr "Noticias fuera de línea"
+
+#: src/screens/Onboarding/StepTopicalFeeds.tsx:80
+#~ msgid "Feeds can be topical as well!"
+#~ msgstr ""
+
+#: src/tours/HomeTour.tsx:88
+#~ msgid "Find more feeds and accounts to follow in the Explore page."
+#~ msgstr ""
+
+#: src/tours/Tooltip.tsx:149
+#~ msgid "Finish tour and begin using the application"
+#~ msgstr ""
+
+#: src/view/com/modals/EditImage.tsx:116
+#~ msgid "Flip horizontal"
+#~ msgstr ""
+
+#: src/view/com/modals/EditImage.tsx:121
+#: src/view/com/modals/EditImage.tsx:288
+#~ msgid "Flip vertically"
+#~ msgstr ""
+
+#: src/screens/Onboarding/StepSuggestedAccounts/index.tsx:187
+#~ msgid "Follow All"
+#~ msgstr "Seguir a todos"
+
+#: src/screens/Onboarding/StepSuggestedAccounts/index.tsx:182
+#~ msgid "Follow selected accounts and continue to the next step"
+#~ msgstr ""
+
+#: src/components/KnownFollowers.tsx:169
+#~ msgid "Followed by"
+#~ msgstr ""
+
+#: src/view/com/profile/ProfileCard.tsx:190
+#~ msgid "Followed by {0}"
+#~ msgstr "Seguido por {0}"
+
+#: src/view/screens/PreferencesFollowingFeed.tsx:152
+#~ msgid "Followed users only"
+#~ msgstr "Solo usuarios seguidos"
+
+#: src/tours/HomeTour.tsx:59
+#~ msgid "Following shows the latest posts from people you follow."
+#~ msgstr ""
+
+#: src/components/dms/MessagesNUX.tsx:168
+#~ msgid "Get started"
+#~ msgstr ""
+
+#: src/screens/StarterPack/StarterPackLandingScreen.tsx:189
+#~ msgid "Go back to previous screen"
+#~ msgstr ""
+
+#: src/tours/Tooltip.tsx:138
+#~ msgid "Go to the next step of the tour"
+#~ msgstr ""
+
+#: src/screens/Onboarding/StepSuggestedAccounts/index.tsx:140
+#~ msgid "Here are some accounts for you to follow"
+#~ msgstr ""
+
+#: src/screens/Onboarding/StepTopicalFeeds.tsx:89
+#~ msgid ""
+#~ "Here are some popular topical feeds. You can choose to follow as many as "
+#~ "you like."
+#~ msgstr ""
+
+#: src/screens/Onboarding/StepTopicalFeeds.tsx:84
+#~ msgid ""
+#~ "Here are some topical feeds based on your interests: {interestsText}. You "
+#~ "can choose to follow as many as you like."
+#~ msgstr ""
+
+#: src/view/com/util/forms/PostDropdownBtn.tsx:390
+#: src/view/com/util/forms/PostDropdownBtn.tsx:392
+#~ msgid "Hide post"
+#~ msgstr "Ocultar post"
+
+#: src/view/com/modals/SelfLabel.tsx:128
+#~ msgid "If none are selected, suitable for all ages."
+#~ msgstr "Si no se selecciona ninguno, es apto para todas las edades."
+
+#: src/view/com/modals/AltImage.tsx:122
+#~ msgid "Image alt text"
+#~ msgstr "Texto alt da imaxe"
+
+#: src/screens/Login/LoginForm.tsx:221
+#~ msgid "Input the password tied to {identifier}"
+#~ msgstr ""
+
+#: src/components/dms/MessagesNUX.tsx:82
+#~ msgid "Introducing Direct Messages"
+#~ msgstr ""
+
+#: src/screens/Onboarding/StepFollowingFeed.tsx:65
+#~ msgid "It shows posts from the people you follow as they happen."
+#~ msgstr ""
+
+#: src/components/dialogs/nuxs/TenMillion/index.tsx:492
+#~ msgid "Joined {0}"
+#~ msgstr ""
+
+#: src/components/moderation/LabelsOnMe.tsx:59
+#~ msgid "label has been placed on this {labelTarget}"
+#~ msgstr ""
+
+#: src/components/moderation/LabelsOnMe.tsx:61
+#~ msgid "labels have been placed on this {labelTarget}"
+#~ msgstr ""
+
+#: src/view/screens/Settings/index.tsx:310
+#~ msgid "Legacy storage cleared, you need to restart the app now."
+#~ msgstr ""
+
+#: src/view/com/util/post-ctrls/PostCtrls.tsx:197
+#~ msgid "Like"
+#~ msgstr ""
+
+#: src/view/com/feeds/FeedSourceCard.tsx:268
+#~ msgid "Liked by {0} {1}"
+#~ msgstr ""
+
+#: src/components/LabelingServiceCard/index.tsx:72
+#~ msgid "Liked by {count} {0}"
+#~ msgstr ""
+
+#: src/screens/Profile/Header/ProfileHeaderLabeler.tsx:287
+#: src/screens/Profile/Header/ProfileHeaderLabeler.tsx:301
+#: src/view/screens/ProfileFeed.tsx:600
+#~ msgid "Liked by {likeCount} {0}"
+#~ msgstr ""
+
+#: src/screens/Feeds/NoFollowingFeed.tsx:38
+#~ msgid "Looks like you're missing a following feed."
+#~ msgstr ""
+
+#: src/Navigation.tsx:307
+#~ msgid "Messaging settings"
+#~ msgstr ""
+
+#: src/screens/Settings/AppearanceSettings.tsx:78
+#~ msgid "Mode"
+#~ msgstr ""
+
+#: src/components/dialogs/MutedWords.tsx:148
+#~ msgid "Mute in tags only"
+#~ msgstr ""
+
+#: src/components/dialogs/MutedWords.tsx:133
+#~ msgid "Mute in text & tags"
+#~ msgstr ""
+
+#: src/components/dms/ConvoMenu.tsx:136
+#: src/components/dms/ConvoMenu.tsx:142
+#~ msgid "Mute notifications"
+#~ msgstr ""
+
+#: src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerNative.tsx:168
+#~ msgid "Muted"
+#~ msgstr "Silenciado"
+
+#: src/view/com/util/post-embeds/ExternalLinkEmbed.tsx:86
+#~ msgid "Navigate to starter pack"
+#~ msgstr "Navegar ao paquete de inicio"
+
+#: src/components/dms/NewChat.tsx:240
+#~ msgid "No search results found for \"{searchText}\"."
+#~ msgstr ""
+
+#: src/view/com/composer/threadgate/ThreadgateBtn.tsx:46
+#~ msgid "Nobody can reply"
+#~ msgstr ""
+
+#: src/view/com/modals/SelfLabel.tsx:135
+#~ msgid "Not Applicable."
+#~ msgstr "No aplicable."
+
+#: src/screens/Signup/index.tsx:145
+#~ msgid "of"
+#~ msgstr ""
+
+#: src/components/dialogs/nuxs/TenMillion/index.tsx:175
+#~ msgid ""
+#~ "Oh no! We weren't able to generate an image for you to share. Rest assured, "
+#~ "we're glad you're here 🦋"
+#~ msgstr ""
+
+#: src/components/StarterPack/QrCode.tsx:69
+#~ msgid "on"
+#~ msgstr ""
+
+#: src/lib/hooks/useTimeAgo.ts:81
+#~ msgid "on {str}"
+#~ msgstr ""
+
+#: src/tours/Tooltip.tsx:118
+#~ msgid "Onboarding tour step {0}: {1}"
+#~ msgstr ""
+
+#: src/components/WhoCanReply.tsx:245
+#~ msgid "Only {0} can reply"
+#~ msgstr ""
+
+#: src/view/com/notifications/FeedItem.tsx:349
+#~ msgid "Opens an expanded list of users in this notification"
+#~ msgstr ""
+
+#: src/view/com/home/HomeHeaderLayout.web.tsx:77
+#: src/view/screens/Feeds.tsx:417
+#~ msgid "Opens screen to edit Saved Feeds"
+#~ msgstr ""
+
+#: src/screens/Messages/List/index.tsx:86
+#~ msgid "Opens the message settings page"
+#~ msgstr ""
+
+#: src/screens/Messages/Settings.tsx:97
+#: src/screens/Messages/Settings.tsx:104
+#~ msgid "Play notification sounds"
+#~ msgstr ""
+
+#: src/view/com/composer/Composer.tsx:359
+#~ msgid "Please wait for your link card to finish loading"
+#~ msgstr "Por favor, espera a que tu tarjeta de enlace termine de cargarse"
+
+#: src/components/dialogs/MutedWords.tsx:89
+#~ msgid "Posts can be muted based on their text, their tags, or both."
+#~ msgstr ""
+
+#: src/screens/Messages/Conversation/MessagesList.tsx:47
+#: src/screens/Messages/Conversation/MessagesList.tsx:53
+#~ msgid "Press to Retry"
+#~ msgstr ""
+
+#: src/components/dms/MessagesNUX.tsx:91
+#~ msgid "Privately chat with other users."
+#~ msgstr ""
+
+#: src/view/com/composer/Composer.tsx:579
+#~ msgid "Publish post"
+#~ msgstr "Publicar"
+
+#: src/view/com/composer/Composer.tsx:579
+#~ msgid "Publish reply"
+#~ msgstr "Publicar resposta"
+
+#: src/tours/Tooltip.tsx:111
+#~ msgid "Quick tip"
+#~ msgstr ""
+
+#: src/view/com/modals/EditImage.tsx:237
+#~ msgid "Ratios"
+#~ msgstr "Proporciones"
+
+#: src/components/dms/MessageReportDialog.tsx:149
+#~ msgid "Reason: {0}"
+#~ msgstr ""
+
+#: src/view/com/composer/ExternalEmbedRemoveBtn.tsx:28
+#~ msgid "Remove image preview"
+#~ msgstr "Eliminar a vista previa da imaxe"
+
+#: src/view/com/composer/ExternalEmbed.tsx:88
+#~ msgid "Removes default thumbnail from {0}"
+#~ msgstr ""
+
+#: src/view/com/composer/ExternalEmbedRemoveBtn.tsx:29
+#~ msgid "Removes the attachment"
+#~ msgstr "Remueve adjunto"
+
+#: src/view/com/composer/ExternalEmbedRemoveBtn.tsx:29
+#~ msgid "Removes the image preview"
+#~ msgstr ""
+
+#: src/view/com/threadgate/WhoCanReply.tsx:123
+#~ msgid "Replies on this thread are disabled"
+#~ msgstr ""
+
+#: src/components/WhoCanReply.tsx:243
+#~ msgid "Replies to this thread are disabled"
+#~ msgstr "Las respostas a este hilo están desactivadas"
+
+#: src/view/screens/PreferencesFollowingFeed.tsx:142
+#~ msgid "Reply Filters"
+#~ msgstr "Filtros de respostas"
+
+#: src/components/dms/ConvoMenu.tsx:146
+#: src/components/dms/ConvoMenu.tsx:150
+#~ msgid "Report account"
+#~ msgstr ""
+
+#: src/screens/Messages/Conversation/MessageListError.tsx:54
+#~ msgid "Retry."
+#~ msgstr "Reintentar."
+
+#: src/view/com/modals/AltImage.tsx:132
+#~ msgid "Save alt text"
+#~ msgstr "Guardar texto alternativo"
+
+#: src/view/com/modals/EditProfile.tsx:227
+#~ msgid "Save Changes"
+#~ msgstr "Guardar cambios"
+
+#: src/view/com/lightbox/Lightbox.tsx:81
+#~ msgid "Saved to your camera roll."
+#~ msgstr "Guardado en tu galería."
+
+#: src/view/com/modals/EditProfile.tsx:220
+#~ msgid "Saves any changes to your profile"
+#~ msgstr "Guarda os cambios en tu perfil"
+
+#: src/components/TagMenu/index.tsx:155
+#~ msgid "Search for all posts by @{authorHandle} with tag {displayTag}"
+#~ msgstr "Buscar todas las publicacións de @{authorHandle} con a etiqueta {displayTag}"
+
+#: src/components/TagMenu/index.tsx:104
+#~ msgid "Search for all posts with tag {displayTag}"
+#~ msgstr "Buscar todas las publicacións con a etiqueta {displayTag}"
+
+#: src/components/dms/NewChat.tsx:226
+#~ msgid "Search for someone to start a conversation with."
+#~ msgstr "Buscar a alguien para comenzar una conversación."
+
+#: src/view/com/notifications/FeedItem.tsx:411
+#: src/view/com/util/UserAvatar.tsx:402
+#~ msgid "See profile"
+#~ msgstr "Ver perfil"
+
+#: src/screens/Onboarding/StepSuggestedAccounts/index.tsx:52
+#~ msgid "Select some accounts below to follow"
+#~ msgstr "Seleccionar algunas contas para seguir abajo"
+
+#: src/screens/Onboarding/StepTopicalFeeds.tsx:100
+#~ msgid "Select topical feeds to follow from the list below"
+#~ msgstr "Seleccionar feeds temáticos para seguir da lista a continuación"
+
+#: src/screens/Onboarding/StepModeration/index.tsx:63
+#~ msgid "Select what you want to see (or not see), and we’ll handle the rest."
+#~ msgstr "Elige lo que quieres ver e nosotros nos encargaremos do resto."
+
+#: src/screens/Onboarding/StepAlgoFeeds/index.tsx:117
+#~ msgid "Select your primary algorithmic feeds"
+#~ msgstr ""
+
+#: src/screens/Onboarding/StepAlgoFeeds/index.tsx:133
+#~ msgid "Select your secondary algorithmic feeds"
+#~ msgstr ""
+
+#: src/view/screens/Settings/index.tsx:463
+#~ msgid "Sets color theme to dark"
+#~ msgstr ""
+
+#: src/view/screens/Settings/index.tsx:456
+#~ msgid "Sets color theme to light"
+#~ msgstr ""
+
+#: src/view/screens/Settings/index.tsx:450
+#~ msgid "Sets color theme to system setting"
+#~ msgstr ""
+
+#: src/view/screens/Settings/index.tsx:489
+#~ msgid "Sets dark theme to the dark theme"
+#~ msgstr ""
+
+#: src/view/screens/Settings/index.tsx:482
+#~ msgid "Sets dark theme to the dim theme"
+#~ msgstr ""
+
+#: src/view/com/modals/crop-image/CropImage.web.tsx:146
+#~ msgid "Sets image aspect ratio to square"
+#~ msgstr ""
+
+#: src/view/com/modals/crop-image/CropImage.web.tsx:136
+#~ msgid "Sets image aspect ratio to tall"
+#~ msgstr ""
+
+#: src/view/com/modals/crop-image/CropImage.web.tsx:126
+#~ msgid "Sets image aspect ratio to wide"
+#~ msgstr ""
+
+#: src/components/dialogs/nuxs/TenMillion/index.tsx:621
+#~ msgid "Share image externally"
+#~ msgstr ""
+
+#: src/components/dialogs/nuxs/TenMillion/index.tsx:639
+#~ msgid "Share image in post"
+#~ msgstr ""
+
+#: src/view/screens/Search/Search.tsx:889
+#~ msgid "Show advanced filters"
+#~ msgstr ""
+
+#: src/view/screens/PreferencesFollowingFeed.tsx:68
+#~ msgid "Show all replies"
+#~ msgstr ""
+
+#: src/screens/Profile/Header/ProfileHeaderStandard.tsx:215
+#~ msgid "Show follows similar to {0}"
+#~ msgstr ""
+
+#: src/screens/Onboarding/StepFollowingFeed.tsx:119
+#~ msgid "Show quote-posts in Following feed"
+#~ msgstr "Mostrar citaciones en Siguiendo"
+
+#: src/screens/Onboarding/StepFollowingFeed.tsx:135
+#~ msgid "Show quotes in Following"
+#~ msgstr "Mostrar citaciones en Siguiendo"
+
+#: src/screens/Onboarding/StepFollowingFeed.tsx:95
+#~ msgid "Show re-posts in Following feed"
+#~ msgstr ""
+
+#: src/screens/Onboarding/StepFollowingFeed.tsx:87
+#~ msgid "Show replies in Following"
+#~ msgstr "Mostrar respostas en Siguiendo"
+
+#: src/screens/Onboarding/StepFollowingFeed.tsx:71
+#~ msgid "Show replies in Following feed"
+#~ msgstr "Mostrar respostas en o feed de Siguiendo"
+
+#: src/view/screens/PreferencesFollowingFeed.tsx:70
+#~ msgid "Show replies with at least {value} {0}"
+#~ msgstr ""
+
+#: src/screens/Onboarding/StepFollowingFeed.tsx:111
+#~ msgid "Show reposts in Following"
+#~ msgstr "Mostrar reposts en Siguiendo"
+
+#: src/view/com/notifications/FeedItem.tsx:347
+#~ msgid "Show users"
+#~ msgstr "Mostrar usuarios"
+
+#: src/view/com/post-thread/PostThreadFollowBtn.tsx:128
+#~ msgid "Shows posts from {0} in your feed"
+#~ msgstr ""
+
+#: src/view/shell/NavSignupCard.tsx:47
+#~ msgid "Sign up or sign in to join the conversation"
+#~ msgstr "Inicia sesión o crea una conta para unirte a a conversación"
+
+#: src/screens/StarterPack/Wizard/index.tsx:203
+#~ msgid "Some subtitle"
+#~ msgstr ""
+
+#: src/components/moderation/LabelsOnMeDialog.tsx:169
+#~ msgid "Source: <0>{0}</0>"
+#~ msgstr ""
+
+#: src/components/moderation/LabelsOnMeDialog.tsx:163
+#~ msgid "Source: <0>{sourceName}</0>"
+#~ msgstr ""
+
+#: src/view/com/modals/crop-image/CropImage.web.tsx:145
+#~ msgid "Square"
+#~ msgstr "Cuadrado"
+
+#: src/components/dms/MessagesNUX.tsx:161
+#~ msgid "Start chatting"
+#~ msgstr ""
+
+#: src/tours/Tooltip.tsx:99
+#~ msgid ""
+#~ "Start of onboarding tour window. Do not move backward. Instead, go forward "
+#~ "for more options, or press to skip."
+#~ msgstr ""
+
+#: src/screens/Signup/index.tsx:145
+#~ msgid "Step"
+#~ msgstr "Paso"
+
+#: src/screens/Onboarding/StepAlgoFeeds/FeedCard.tsx:172
+#: src/screens/Onboarding/StepAlgoFeeds/FeedCard.tsx:307
+#~ msgid "Subscribe to the {0} feed"
+#~ msgstr ""
+
+#: src/view/screens/Search/Search.tsx:425
+#~ msgid "Suggested Follows"
+#~ msgstr "Usuarios sugeridos a seguir"
+
+#: src/tours/HomeTour.tsx:48
+#~ msgid "Switch between feeds to control your experience."
+#~ msgstr ""
+
+#: src/components/dialogs/MutedWords.tsx:323
+#~ msgid "tag"
+#~ msgstr ""
+
+#: src/view/com/modals/crop-image/CropImage.web.tsx:135
+#~ msgid "Tall"
+#~ msgstr "Alto"
+
+#: src/view/com/util/images/AutoSizedImage.tsx:70
+#~ msgid "Tap to view fully"
+#~ msgstr ""
+
+#: src/components/dialogs/nuxs/TenMillion/index.tsx:518
+#~ msgid "Ten Million"
+#~ msgstr "Diez Millones"
+
+#: src/components/dialogs/MutedWords.tsx:323
+#~ msgid "text"
+#~ msgstr "texto"
+
+#: src/components/dialogs/nuxs/TenMillion/index.tsx:593
+#~ msgid "Thanks for being one of our first 10 million users."
+#~ msgstr "Gracias por ser uno de nuestros primeros 10 millones de usuarios."
+
+#: src/components/intents/VerifyEmailIntentDialog.tsx:74
+#~ msgid "Thanks, you have successfully verified your email address."
+#~ msgstr "Gracias, has verificado tu dirección de correo electrónico exitosamente."
+
+#: src/components/moderation/ModerationDetailsDialog.tsx:127
+#~ msgid "the author"
+#~ msgstr "el autor"
+
+#: src/screens/Onboarding/StepAlgoFeeds/index.tsx:141
+#~ msgid "There are many feeds to try:"
+#~ msgstr "Hay muchos máis feeds que probar!"
+
+#: src/screens/Profile/Header/ProfileHeaderLabeler.tsx:112
+#: src/view/screens/ProfileFeed.tsx:539
+#~ msgid ""
+#~ "There was an an issue contacting the server, please check your internet "
+#~ "connection and try again."
+#~ msgstr ""
+#~ "Hubo un problema ao contactar con o servidor, por favor verifica tu "
+#~ "conexión a internet e vuelve a intentarlo."
+
+#: src/view/com/posts/FeedErrorMessage.tsx:145
+#~ msgid ""
+#~ "There was an an issue removing this feed. Please check your internet "
+#~ "connection and try again."
+#~ msgstr ""
+#~ "Hubo un problema ao eliminar este feed. Por favor verifica tu conexión a "
+#~ "internet e vuelve a intentarlo."
+
+#: src/view/com/posts/FeedShutdownMsg.tsx:52
+#: src/view/com/posts/FeedShutdownMsg.tsx:71
+#: src/view/screens/ProfileFeed.tsx:204
+#~ msgid ""
+#~ "There was an an issue updating your feeds, please check your internet "
+#~ "connection and try again."
+#~ msgstr ""
+#~ "Hubo un problema ao actualizar tus feeds, por favor verifica tu conexión a "
+#~ "internet e vuelve a intentarlo."
+
+#: src/screens/Messages/Conversation/MessageListError.tsx:23
+#~ msgid "There was an issue connecting to the chat."
+#~ msgstr "Hubo un problema ao conectarse ao chat."
+
+#: src/screens/Onboarding/StepModeration/AdultContentEnabledPref.tsx:65
+#~ msgid "There was an issue syncing your preferences with the server"
+#~ msgstr "Hubo un problema ao sincronizar tus preferencias con o servidor"
+
+#: src/screens/Onboarding/StepSuggestedAccounts/index.tsx:146
+#~ msgid "These are popular accounts you might like:"
+#~ msgstr "Estas son contas populares que podrían gustarte:"
+
+#: src/components/moderation/LabelsOnMeDialog.tsx:260
+#~ msgid "This appeal will be sent to <0>{0}</0>."
+#~ msgstr "Esta apelación será enviada a <0>{0}</0>."
+
+#: src/screens/Messages/Conversation/MessageListError.tsx:26
+#~ msgid "This chat was disconnected due to a network error."
+#~ msgstr "Este chat fue desconectado debido a un error de red."
+
+#: src/screens/Profile/Sections/Feed.tsx:59
+#: src/view/screens/ProfileFeed.tsx:471
+#: src/view/screens/ProfileList.tsx:729
+#~ msgid "This feed is empty!"
+#~ msgstr "Este feed está vacío!"
+
+#: src/components/moderation/ModerationDetailsDialog.tsx:124
+#~ msgid "This label was applied by {0}."
+#~ msgstr "Esta etiqueta fue aplicada por {0}."
+
+#: src/components/moderation/LabelsOnMeDialog.tsx:165
+#~ msgid "This label was applied by you"
+#~ msgstr "Esta etiqueta fue aplicada por ti"
+
+#: src/view/com/util/forms/PostDropdownBtn.tsx:443
+#~ msgid "This post will be hidden from feeds."
+#~ msgstr "Esta publicación será ocultada de os feeds."
+
+#: src/view/com/modals/SelfLabel.tsx:137
+#~ msgid "This warning is only available for posts with media attached."
+#~ msgstr "Esta advertencia solo está disponible para publicacións con medios adjuntos."
+
+#: src/components/dialogs/MutedWords.tsx:283
+#~ msgid ""
+#~ "This will delete {0} from your muted words. You can always add it back "
+#~ "later."
+#~ msgstr ""
+#~ "Esto eliminará {0} de tus palabras silenciadas. Siempre puedes agregarlas "
+#~ "de nuevo máis tarde."
+
+#: src/components/WhoCanReply.tsx:109
+#~ msgid "Thread settings updated"
+#~ msgstr "Configuraciones de hilo actualizadas"
+
+#: src/components/dialogs/nuxs/TenMillion/index.tsx:597
+#~ msgid "Together, we're rebuilding the social internet. We're glad you're here."
+#~ msgstr "Juntos, estamos reconstruyendo o internet social. Nos alegra que estés aquí."
+
+#: src/components/dialogs/MutedWords.tsx:112
+#~ msgid "Toggle between muted word options."
+#~ msgstr "Alternar entre opciones de palabras silenciadas."
+
+#: src/view/com/modals/EditImage.tsx:272
+#~ msgid "Transformations"
+#~ msgstr "Transformaciones"
+
+#: src/view/com/profile/ProfileHeaderSuggestedFollows.tsx:247
+#~ msgid "Unfollow"
+#~ msgstr "Dejar de seguir"
+
+#: src/view/com/util/post-ctrls/PostCtrls.tsx:197
+#~ msgid "Unlike"
+#~ msgstr "No me gusta"
+
+#: src/components/dms/ConvoMenu.tsx:140
+#~ msgid "Unmute notifications"
+#~ msgstr "Demutear notificaciones"
+
+#: src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerNative.tsx:168
+#~ msgid "Unmuted"
+#~ msgstr "Desmutado"
+
+#: src/lib/moderation/useReportOptions.ts:85
+#~ msgid "Unwanted sexual content"
+#~ msgstr "Contido sexual no deseado"
+
+#: src/view/com/modals/UserAddRemoveLists.tsx:82
+#~ msgid "Update {displayName} in Lists"
+#~ msgstr "Actualizar {displayName} en Listas"
+
+#: src/components/WhoCanReply.tsx:280
+#~ msgid "users followed by <0/>"
+#~ msgstr "usuarios seguidos por <0/>"
+
+#: src/view/com/modals/ChangeHandle.tsx:510
+#~ msgid "Verify {0}"
+#~ msgstr "Verificar {0}"
+
+#: src/view/com/composer/videos/state.ts:27
+#~ msgid "Videos cannot be larger than 50MB"
+#~ msgstr "Los videos no pueden ser mayores de 50MB"
+
+#: src/components/dialogs/MutedWords.tsx:203
+#~ msgid ""
+#~ "We recommend avoiding common words that appear in many posts, since it can "
+#~ "result in no posts being shown."
+#~ msgstr ""
+#~ "Recomendamos evitar palabras comunes que aparecen en muchos posts, ya que "
+#~ "puede resultar en que no se muestren posts."
+
+#: src/screens/Onboarding/StepAlgoFeeds/index.tsx:125
+#~ msgid "We recommend our \"Discover\" feed:"
+#~ msgstr "Recomendamos nuestro feed \"Discover\":"
+
+#: src/screens/Profile/Header/ProfileHeaderLabeler.tsx:330
+#~ msgid ""
+#~ "We're sorry! You can only subscribe to ten labelers, and you've reached "
+#~ "your limit of ten."
+#~ msgstr ""
+#~ "Lo sentimos. Solo puedes suscribirte a hasta 10 etiquetadores, e has "
+#~ "alcanzado o límite."
+
+#: src/components/dms/MessagesNUX.tsx:110
+#: src/components/dms/MessagesNUX.tsx:124
+#~ msgid "Who can message you?"
+#~ msgstr "Quién puede enviarte mensajes?"
+
+#: src/components/WhoCanReply.tsx:212
+#~ msgid "Who can reply dialog"
+#~ msgstr "Quién puede responder en o diálogo"
+
+#: src/components/WhoCanReply.tsx:216
+#~ msgid "Who can reply?"
+#~ msgstr "Quién puede responder?"
+
+#: src/view/com/modals/crop-image/CropImage.web.tsx:125
+#~ msgid "Wide"
+#~ msgstr "Ancho"
+
+#: src/components/dms/MessageItem.tsx:183
+#~ msgid "Yesterday, {time}"
+#~ msgstr "Ayer, {time}"
+
+#: src/screens/Onboarding/StepFollowingFeed.tsx:143
+#~ msgid "You can change these settings later."
+#~ msgstr "Puedes cambiar estos axustes luego."
+
+#: src/components/dms/MessagesNUX.tsx:119
+#~ msgid "You can change this at any time."
+#~ msgstr "Puedes cambiar esto en cualquier momento."
+
+#: src/view/screens/Feeds.tsx:477
+#~ msgid "You don't have any saved feeds!"
+#~ msgstr "No tienes ningún feed guardado!"
+
+#: src/screens/Messages/List/index.tsx:200
+#~ msgid "You have no messages yet. Start a conversation with someone!"
+#~ msgstr "Aún no tienes ningún mensaje. Comienza una conversación con alguien!"
+
+#: src/screens/StarterPack/Wizard/State.tsx:95
+#~ msgid "You may only add up to 50 feeds"
+#~ msgstr "Sólo puedes añadir hasta 50 feeds"
+
+#: src/screens/StarterPack/Wizard/State.tsx:78
+#~ msgid "You may only add up to 50 profiles"
+#~ msgstr "Sólo puedes añadir hasta 50 perfiles"
+
+#: src/screens/Onboarding/StepModeration/AdultContentEnabledPref.tsx:110
+#~ msgid "You must be 18 years or older to enable adult content"
+#~ msgstr "Tienes que tener 18 años o máis para poder activar o contido adulto"
+
+#: src/screens/Onboarding/StepModeration/index.tsx:60
+#~ msgid "You're in control"
+#~ msgstr "Tu tienes o control"
+
+#: src/screens/Onboarding/StepFollowingFeed.tsx:62
+#~ msgid "Your default feed is \"Following\""
+#~ msgstr "Tu feed principal es \"Siguiendo\""
+
+#: src/view/com/modals/Repost.tsx:66
+#~ msgctxt "action"
+#~ msgid "Quote post"
+#~ msgstr "Citar una post"
+
+#: src/view/com/modals/Repost.tsx:71
+#~ msgctxt "action"
+#~ msgid "Quote Post"
+#~ msgstr "Citar una post"


### PR DESCRIPTION
Galician language.

Tradución total actualizada:
- terminoloxía máis neutra
- recuperación de traducións feitas noutras plataformas de microblogging
- comparativa con outras linguas para ir acorde
- utilización do acordo de mínimos da lingua galega de 2005